### PR TITLE
[WIP] Collaborator addons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "primo-server",
-  "version": "2.0.0--beta.41",
+  "version": "2.0.0--beta.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "primo-server",
-      "version": "2.0.0--beta.41",
+      "version": "2.0.0--beta.48",
       "dependencies": {
         "@fontsource/fira-code": "^5.0.5",
         "@iconify/svelte": "^2.2.1",

--- a/src/lib/components/Modals/ServerInvitation.svelte
+++ b/src/lib/components/Modals/ServerInvitation.svelte
@@ -12,20 +12,19 @@
 
   async function invite_editor() {
     loading = true
-    await supabase.from('invitations').insert({
-      email,
-      inviter_email: $page.data.user.email,
-      role,
-      server_invitation: true,
-    })
     const { data } = await axios.post('/api/invitations', {
       url: $page.url.origin,
       email,
       role,
       server_invitation: true,
     })
-
     if (data.success) {
+      await supabase.from('invitations').insert({
+        email,
+        inviter_email: $page.data.user.email,
+        role,
+        server_invitation: true,
+      })
       invitations = await get_invitations()
     } else {
       alert(data.error)
@@ -66,7 +65,8 @@
     ({
       DEV: 'Developer',
       EDITOR: 'Content Editor',
-    }[role])
+      ADMIN: 'Admin',
+    })[role]
 </script>
 
 <div class="Invitation">
@@ -91,6 +91,7 @@
           <select bind:value={role}>
             <option value="DEV">{Role('DEV')}</option>
             <option value="EDITOR">{Role('EDITOR')}</option>
+            <option value="ADMIN">{Role('ADMIN')}</option>
           </select>
         </div>
         <button type="submit" disabled={!email}>

--- a/src/lib/components/Modals/ServerInvitation.svelte
+++ b/src/lib/components/Modals/ServerInvitation.svelte
@@ -21,13 +21,16 @@
       server_invitation: true,
     })
     if (data.success) {
-      await supabase.from('invitations').insert({
-        email,
-        inviter_email: $page.data.user.email,
-        role,
-        server_invitation: true,
-      })
+      if (data.isNew) {
+        await supabase.from('invitations').insert({
+          email,
+          inviter_email: $page.data.user.email,
+          role,
+          server_invitation: true,
+        })
+      }
       invitations = await get_invitations()
+      editors = await get_collaborators()
     } else {
       alert(data.error)
     }

--- a/src/lib/components/Modals/SiteInvitation.svelte
+++ b/src/lib/components/Modals/SiteInvitation.svelte
@@ -16,27 +16,24 @@
 
   async function invite_editor() {
     loading = true
-    const { data: success } = await axios.post('/api/invitations', {
+    const { data: res } = await axios.post('/api/invitations', {
       site: site.id,
       email,
       role,
       server_invitation: false,
       url: $page.url.origin,
     })
-    if (success) {
-      await supabase.from('invitations').insert({
-        email,
-        inviter_email: owner.email,
-        site: site.id,
-        role,
-      })
-      const { data, error } = await supabase
-        .from('invitations')
-        .select('*')
-        .eq('site', site.id)
-      if (data) {
-        invitations = data
+    if (res.success) {
+      if (res.isNew) {
+        await supabase.from('invitations').insert({
+          email,
+          inviter_email: owner.email,
+          site: site.id,
+          role,
+        })
       }
+      invitations = await get_invitations(site.id)
+      editors = await get_collaborators(site.id)
     } else {
       alert('Could not send invitation. Please try again.')
     }

--- a/src/lib/components/Modals/SiteInvitation.svelte
+++ b/src/lib/components/Modals/SiteInvitation.svelte
@@ -2,6 +2,7 @@
   import axios from 'axios'
   import * as timeago from 'timeago.js'
   import { page } from '$app/stores'
+  import Icon from '@iconify/svelte'
 
   export let site
 
@@ -74,6 +75,37 @@
         return { role: item.role, ...item.user }
       })
   }
+
+  async function remove_editor(user_id) {
+    loading = true
+    const { data: success } = await axios.delete('/api/invitations', {
+      params: {
+        site: site.id,
+        user: user_id,
+        server_invitation: false,
+      },
+    })
+    if (success) {
+      get_collaborators(site.id).then((res) => {
+        editors = res
+      })
+    }
+    loading = false
+  }
+
+  async function cancel_invitation(email) {
+    loading = true
+    const { data: success } = await axios.put('/api/invitations', {
+      site: site.id,
+      email,
+    })
+    if (success) {
+      get_invitations(site.id).then((res) => {
+        invitations = res
+      })
+    }
+    loading = false
+  }
 </script>
 
 <div class="Invitation">
@@ -107,6 +139,13 @@
               <span class="letter">{email[0]}</span>
               <span class="email">{email}</span>
               <span>Sent {timeago.format(created_at)}</span>
+              <button
+                class="site-button"
+                on:click={() => cancel_invitation(email)}
+              >
+                <Icon icon="pepicons-pop:trash" />
+                <span>Cancel</span>
+              </button>
             </li>
           {/each}
         </ul>
@@ -120,11 +159,15 @@
           <span class="email">{owner.email}</span>
           <span class="role">Owner</span>
         </li>
-        {#each editors as { role, email }}
+        {#each editors as { id, role, email }}
           <li>
             <span class="letter">{email[0]}</span>
             <span class="email">{email}</span>
             <span class="role">{role}</span>
+            <button class="site-button" on:click={() => remove_editor(id)}>
+              <Icon icon="pepicons-pop:trash" />
+              <span>Remove</span>
+            </button>
           </li>
         {/each}
       </ul>

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -78,7 +78,7 @@ export type User = {
 	email: string;
 	server_member: boolean;
 	admin: boolean;
-	role: 'DEV' | 'EDITOR';
+	role: 'DEV' | 'EDITOR' | 'OWNER';
 	created_at: string;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -69,7 +69,8 @@
               <div class="site-name">
                 {#if siteBeingEdited.id === site.id}
                   <form
-                    on:submit|preventDefault={() => (siteBeingEdited = { id: null, element: null })}
+                    on:submit|preventDefault={() =>
+                      (siteBeingEdited = { id: null, element: null })}
                   >
                     <input
                       bind:this={siteBeingEdited.element}
@@ -98,9 +99,12 @@
                   {site.id}
                 </button>
               {/if}
-              {#if $page.data.user.admin}
+              {#if $page.data.user.admin || site.collaborators.some((c) => c.site === $page.data.user.id && c.role === 'OWNER')}
                 <div class="buttons">
-                  <button on:click={() => beginInvitation(site)} class="site-button">
+                  <button
+                    on:click={() => beginInvitation(site)}
+                    class="site-button"
+                  >
                     <Icon icon="clarity:users-solid" />
                     <span>Collaborators</span>
                   </button>
@@ -115,7 +119,10 @@
                     <Icon icon="material-symbols:edit-square-outline-rounded" />
                     <span>Rename</span>
                   </button>
-                  <button class="site-button" on:click={() => delete_site(site)}>
+                  <button
+                    class="site-button"
+                    on:click={() => delete_site(site)}
+                  >
                     <Icon icon="pepicons-pop:trash" />
                     <span>Delete</span>
                   </button>

--- a/src/routes/api/invitations/+server.js
+++ b/src/routes/api/invitations/+server.js
@@ -110,30 +110,6 @@ export async function PUT({ request }) { // cancel an invitation
     if (error) return json({ success: !error, error: error?.message })
   }
 
-  const { data: user, error: err } = await supabase_admin
-    .from('users')
-    .select('id')
-    .eq('email', email)
-    .single()
-
-  if (err) return json({ success: !err, error: err?.message })
-
-  if (site) {
-    const { error } = await supabase_admin
-      .from('collaborators')
-      .delete()
-      .match({ user: user.id, site })
-
-    if (error) return json({ success: !error, error: error?.message })
-  } else {
-    const { error } = await supabase_admin
-      .from('server_members')
-      .delete()
-      .match({ user: user.id })
-
-    if (error) return json({ success: !error, error: error?.message })
-  }
-
   // Remove from 'users'
   const { data, error: err2 } = await supabase_admin.auth.admin.deleteUser(user.id)
   if (err2) return json({ success: !err2, error: err2?.message })

--- a/src/routes/api/invitations/+server.js
+++ b/src/routes/api/invitations/+server.js
@@ -59,3 +59,39 @@ export async function POST({ request }) {
   console.error(error)
   return json({ success: !error, error: error?.message })
 }
+
+export async function DELETE({ url }) {
+  const user = url.searchParams.get('user')
+  const site = url.searchParams.get('site')
+  const server_invitation = url.searchParams.get('server_invitation') === 'true'
+
+  // Remove from 'server_members' or 'collaborators'
+  const { error } = server_invitation ?
+    await supabase_admin
+      .from('server_members')
+      .delete()
+      .eq('user', user)
+    : await supabase_admin
+      .from('collaborators')
+      .delete()
+      .match({ user, site })
+
+  console.error(error)
+  return json({ success: !error, error: error?.message })
+}
+
+export async function PUT({ request }) {
+  const {
+    email,
+    site = null
+  } = await request.json()
+
+  // Remove from 'invitations'
+  const { error } = await supabase_admin
+    .from('collaborators')
+    .delete()
+    .match({ email, site })
+
+  console.error(error)
+  return json({ success: !error, error: error?.message })
+}


### PR DESCRIPTION
Picking up from #389 

I'm almost done with this but it still feels lacking. Using the `PUT` method to cancel invites is just lazy (sorry), but the alternative is to refactor all API calls to use proper [Form Actions](https://kit.svelte.dev/docs/form-actions#named-actions).

I'm mostly inclined to do a refactoring on the whole user model and add some proper ACL.

## Changes so far

- Can add an existing user's email as collaborator in multiple websites without an invite
- Can remove collaborators
- Can cancel invites [WIP]
- Can make a collaborator the site owner with rights to rename/delete a website and add more collaborators to it
- Can add more server admins

Changing the user role seems too much hassle, thus the workaround is to remove and re-add him with the new role.

## ACL Proposal

- Keep the multiple Admins and drop the Dev/Editor role for them: move the `admin` column to the `users` table and drop the `server_members`
- Introduce spaces:
  - A space is a group of rights where you can add both users and sites
  - Each user can have separate CRUD rights for the whole space
  - Each site can have UD rights of its own (so you can protect a site from being deleted or even archive it to prevent changes).
  - A space can have its own admin (not a server admin) who can edit everything in the space

What do you think?