### PR TITLE
Fix on-page editing functionality

### DIFF
--- a/app/lib/builder/code_generators.ts
+++ b/app/lib/builder/code_generators.ts
@@ -65,10 +65,15 @@ export async function page_html({
 	locale?: (typeof locales)[number]
 	no_js?: boolean
 }) {
+	const site_content = getContent(site, site_fields, site_entries)
+	const page_type_content = getContent(page_type, page_type_fields, page_type_entries)
+	
+	// Flatten the content for template variables (extract from locale structure)
 	const site_data = {
-		...getContent(site, site_fields, site_entries),
-		...getContent(page_type, page_type_fields, page_type_entries)
+		...(site_content[locale] || {}),
+		...(page_type_content[locale] || {})
 	}
+	
 	const head = {
 		code: site.head + page_type.head,
 		data: site_data

--- a/app/lib/builder/components/Content.svelte
+++ b/app/lib/builder/components/Content.svelte
@@ -6,7 +6,7 @@
 	import { getDirectEntries, type Entity } from '$lib/pocketbase/content'
 	import type { Entry } from '$lib/common/models/Entry'
 
-	const { entity, fields, entries, oninput }: { entity: Entity; entries: Entry[]; fields: Field[]; oninput: (values: Record<string, unknown>) => void } = $props()
+	const { minimal, entity, fields, entries, oninput }: { minimal: boolean; entity: Entity; entries: Entry[]; fields: Field[]; oninput: (values: Record<string, unknown>) => void } = $props()
 
 	function check_condition(field: Field) {
 		// TODO: Implement
@@ -41,11 +41,11 @@
 		{@const has_child_fields = field.type === 'repeater' || field.type === 'group'}
 		{@const content_entry = getDirectEntries(entity, field, entries)[0]}
 		{#if is_valid && is_visible}
-			<Card title={has_child_fields ? field.label : null} icon={field_type?.icon}>
+			<Card {minimal} title={has_child_fields ? field.label : null} icon={field_type?.icon}>
 				<div class="field-item" id="field-{field.key}" class:repeater={field.key === 'repeater'}>
 					<Field_Component
 						{entity}
-						field={{ ...field, label: `${field.label} (PAGE FIELD)` }}
+						field={{ ...field, label: field.label }}
 						entry={content_entry}
 						onchange={(value) => {
 							oninput({ [field.key]: value })
@@ -54,7 +54,7 @@
 				</div>
 			</Card>
 		{:else if is_valid && is_visible}
-			<Card title={has_child_fields ? field.label : null} icon={field_type?.icon}>
+			<Card {minimal} title={has_child_fields ? field.label : null} icon={field_type?.icon}>
 				<div class="field-item" id="field-{field.key}" class:repeater={field.key === 'repeater'}>
 					<Field_Component
 						{entity}

--- a/app/lib/builder/components/Fields/Condition.svelte
+++ b/app/lib/builder/components/Fields/Condition.svelte
@@ -8,7 +8,7 @@
 
 	let { field, field_to_compare, comparable_fields, collapsed } = $props()
 
-	let condition = $derived(field.options.condition)
+	let condition = $derived(field.config?.condition)
 
 	const comparisons = [
 		{ icon: 'ph:equals-bold', label: 'Equals', value: '=' },
@@ -34,7 +34,7 @@
 				let default_value = ''
 				const selected_field = comparable_fields.find((f) => f.id === field_id)
 				if (selected_field.type === 'select') {
-					default_value = selected_field.options.options[0]?.value
+					default_value = selected_field.config?.options?.[0]?.value
 				} else {
 					default_value = selected_field.value
 				}
@@ -45,14 +45,14 @@
 				icon: $fieldTypes.find((t) => t.id === f.type).icon,
 				label: f.label,
 				value: f.id,
-				disabled: f.options.condition
+				disabled: f.config?.condition
 			}))}
 		/>
 		<!-- Comparison -->
 		<UI.Select on:input={({ detail: comparison }) => dispatch_update({ comparison })} value={condition.comparison} options={comparisons} />
 		<!-- Value -->
 		{#if field_to_compare?.type === 'select'}
-			<UI.Select fullwidth={true} value={condition.value} on:input={({ detail: value }) => dispatch_update({ value })} options={field_to_compare.options?.options || []} />
+			<UI.Select fullwidth={true} value={condition.value} on:input={({ detail: value }) => dispatch_update({ value })} options={field_to_compare.config?.options || []} />
 		{:else if field_to_compare?.type === 'switch'}
 			<UI.Toggle
 				toggled={condition.value}

--- a/app/lib/builder/components/Fields/ImageFieldOptions.svelte
+++ b/app/lib/builder/components/Fields/ImageFieldOptions.svelte
@@ -6,24 +6,24 @@
 
 	let { field } = $props()
 
-	// Initialize options object if it doesn't exist
-	if (!field.options) field.options = {}
+	// Initialize config object if it doesn't exist
+	if (!field.config) field.config = {}
 
 	// Set defaults if values don't exist
-	if (field.options.maxSizeMB === undefined) field.options.maxSizeMB = 1
-	if (field.options.maxWidthOrHeight === undefined) field.options.maxWidthOrHeight = 1920
+	if (field.config.maxSizeMB === undefined) field.config.maxSizeMB = 1
+	if (field.config.maxWidthOrHeight === undefined) field.config.maxWidthOrHeight = 1920
 
 	// Listen for changes to dispatch updates to parent
 	function handle_change() {
-		dispatch('input', { options: field.options })
+		dispatch('input', { config: field.config })
 	}
 </script>
 
 <div class="ImageFieldOptions">
 	<div class="option-group">
-		<UI.TextInput type="number" label="Max Size (MB)" bind:value={field.options.maxSizeMB} on:input={handle_change} />
+		<UI.TextInput type="number" label="Max Size (MB)" bind:value={field.config.maxSizeMB} on:input={handle_change} />
 	</div>
 	<div class="option-group">
-		<UI.TextInput type="number" label="Max Dimension (px)" bind:value={field.options.maxWidthOrHeight} on:input={handle_change} />
+		<UI.TextInput type="number" label="Max Dimension (px)" bind:value={field.config.maxWidthOrHeight} on:input={handle_change} />
 	</div>
 </div>

--- a/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
@@ -32,11 +32,11 @@
 	const page_type_symbols = $derived(page_type?.symbols() ?? [])
 	const site_symbols = $derived(site?.symbols() ?? [])
 
-	// get the query param to set the tab when navigating from page (i.e. 'Edit Fields')
-	let active_tab = $state(page.url.searchParams.get('t') === 'p' ? 'CONTENT' : 'BLOCKS')
+	// get the query param to set the tab when navigating from page (i.e. 'Manage Fields')
+	let active_tab = $state(page.url.searchParams.get('tab') === 'fields' ? 'CONTENT' : 'BLOCKS')
 	if (browser) {
 		const url = new URL(page.url)
-		url.searchParams.delete('t')
+		url.searchParams.delete('tab')
 		goto(url, { replaceState: true })
 	}
 
@@ -206,7 +206,7 @@
 </Dialog.Root>
 
 <div class="sidebar primo-reset">
-	<Tabs.Root value="blocks" class="p-2">
+	<Tabs.Root value={active_tab === 'CONTENT' ? 'content' : 'blocks'} class="p-2">
 		<Tabs.List class="w-full mb-2">
 			<Tabs.Trigger value="blocks" class="flex-1 flex gap-1">
 				<Cuboid class="w-3" />

--- a/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
@@ -301,6 +301,7 @@
 				{/if}
 				{#if page_type}
 					<Content
+						minimal={true}
 						entity={page_type}
 						{fields}
 						{entries}

--- a/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
@@ -8,9 +8,8 @@
 	import Icon from '@iconify/svelte'
 	import BlockEditor from '$lib/builder/views/modal/BlockEditor.svelte'
 	import BlockPicker from '$lib/builder/views/modal/BlockPicker.svelte'
-	import PageEditor from '$lib/builder/views/modal/PageEditor.svelte'
 	import Sidebar_Symbol from './Sidebar_Symbol.svelte'
-	import Content from '$lib/builder/components/Content.svelte'
+	import Fields from '$lib/builder/components/Fields/FieldsContent.svelte'
 	import { flip } from 'svelte/animate'
 	import { dropTargetForElements } from '../../libraries/pragmatic-drag-and-drop/entry-point/element/adapter.js'
 	import { attachClosestEdge, extractClosestEdge } from '../../libraries/pragmatic-drag-and-drop-hitbox/closest-edge.js'
@@ -121,7 +120,6 @@
 	let editing_block = $state(false)
 	let creating_block = $state(false)
 	let adding_block = $state(false)
-	let editing_page = $state(false)
 	let commit_task = $state<NodeJS.Timeout>()
 </script>
 
@@ -192,18 +190,6 @@
 	</Dialog.Content>
 </Dialog.Root>
 
-<Dialog.Root
-	bind:open={editing_page}
-	onOpenChange={(open) => {
-		if (!open) {
-			manager.discard()
-		}
-	}}
->
-	<Dialog.Content class="z-[999] max-w-[1600px] h-full max-h-[100vh] flex flex-col p-4">
-		<PageEditor onClose={() => (editing_page = false)} />
-	</Dialog.Content>
-</Dialog.Root>
 
 <div class="sidebar primo-reset">
 	<Tabs.Root value={active_tab === 'CONTENT' ? 'content' : 'blocks'} class="p-2">
@@ -291,20 +277,21 @@
 		</Tabs.Content>
 		<Tabs.Content value="content" class="px-1">
 			<div class="page-type-fields">
-				<!-- $userRole === 'DEV' -->
-				{#if true}
-					<!-- <button class="primo--link" style="margin-bottom: 1rem" onclick={() => modal.show('PAGE_EDITOR')}> -->
-					<button class="primo--link" style="margin-bottom: 1rem" onclick={() => (editing_page = true)}>
-						<Icon icon="mdi:code" />
-						<span>Edit Page Type</span>
-					</button>
-				{/if}
 				{#if page_type}
-					<Content
-						minimal={true}
+					<Fields
 						entity={page_type}
 						{fields}
 						{entries}
+						create_field={async (parentId) => {
+							return PageTypeFields.create({
+								type: 'text',
+								key: '',
+								label: '',
+								config: null,
+								page_type: page_type.id,
+								parent: parentId || ''
+							})
+						}}
 						oninput={(values) => {
 							for (const [key, value] of Object.entries(values)) {
 								const field = fields?.find((field) => field.key === key)
@@ -322,6 +309,21 @@
 
 							clearTimeout(commit_task)
 							commit_task = setTimeout(() => manager.commit(), 500)
+						}}
+						onchange={({ id, data }) => {
+							PageTypeFields.update(id, data)
+						}}
+						ondelete={(field_id) => {
+							// PocketBase cascade deletion will automatically clean up all associated entries
+							PageTypeFields.delete(field_id)
+						}}
+						onadd={({ parent, index, subfields }) => {
+							// Create an entry for the repeater item
+							PageTypeEntries.create({
+								field: parent,
+								locale: 'en',
+								value: {}
+							})
 						}}
 					/>
 				{/if}

--- a/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
@@ -83,7 +83,7 @@
 				</Tabs.Trigger>
 				<Tabs.Trigger value="content" class="flex-1 flex gap-1">
 					<SquarePen class="w-3" />
-					<span class="text-xs">Content</span>
+					<span class="text-xs">Fields</span>
 				</Tabs.Trigger>
 			</Tabs.List>
 			<Tabs.Content value="blocks">
@@ -121,6 +121,7 @@
 				{#if page && page_type_fields && page_entries}
 					<div class="page-type-fields">
 						<Content
+							minimal={true}
 							entity={page}
 							fields={page_type_fields}
 							entries={page_entries}
@@ -147,7 +148,15 @@
 				{/if}
 				<!-- $userRole === 'DEV' -->
 				{#if true}
-					<button onclick={() => goto(`/${site?.id}/page-type--${page_type?.id}?t=p`)} class="footer-link">Manage Fields</button>
+					<button
+						onclick={() => {
+							const base_path = pageState.url.pathname.includes('/sites/') ? `/admin/sites/${site?.id}` : '/admin/site'
+							goto(`${base_path}/page-type--${page_type?.id}?t=p`)
+						}}
+						class="footer-link"
+					>
+						Manage Fields
+					</button>
 				{/if}
 			</Tabs.Content>
 		</Tabs.Root>
@@ -155,6 +164,7 @@
 		{#if page && page_type_fields && page_entries}
 			<div class="p-4 page-type-fields">
 				<Content
+					minimal={true}
 					entity={page}
 					fields={page_type_fields}
 					entries={page_entries}

--- a/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
@@ -150,7 +150,7 @@
 				{#if true}
 					<button
 						onclick={() => {
-							const base_path = pageState.url.pathname.includes('/sites/') ? `/admin/sites/${site?.id}` : '/admin/site'
+							const base_path = pageState.url.pathname.startsWith('/admin/sites/') ? `/admin/sites/${site?.id}` : '/admin/site'
 							goto(`${base_path}/page-type--${page_type?.id}?t=p`)
 						}}
 						class="footer-link"

--- a/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
@@ -70,7 +70,7 @@
 		})
 	}
 
-	let commit_task = $state<NodeJS.Timeout>()
+	let commit_task
 </script>
 
 <div class="sidebar primo-reset">
@@ -109,7 +109,7 @@
 					<button
 						onclick={() => {
 							const base_path = pageState.url.pathname.includes('/sites/') ? `/admin/sites/${site?.id}` : '/admin/site'
-							goto(`${base_path}/page-type--${page_type?.id}?t=b`)
+							goto(`${base_path}/page-type--${page_type?.id}?tab=blocks`)
 						}}
 						class="footer-link"
 					>
@@ -151,7 +151,7 @@
 					<button
 						onclick={() => {
 							const base_path = pageState.url.pathname.startsWith('/admin/sites/') ? `/admin/sites/${site?.id}` : '/admin/site'
-							goto(`${base_path}/page-type--${page_type?.id}?t=p`)
+							goto(`${base_path}/page-type--${page_type?.id}?tab=fields`)
 						}}
 						class="footer-link"
 					>
@@ -194,7 +194,7 @@
 			<button
 				onclick={() => {
 					const base_path = pageState.url.pathname.includes('/sites/') ? `/admin/sites/${site?.id}` : '/admin/site'
-					goto(`${base_path}/page-type--${page_type?.id}?t=p`)
+					goto(`${base_path}/page-type--${page_type?.id}?tab=fields`)
 				}}
 				class="footer-link mb-2 mr-2"
 			>

--- a/app/lib/builder/converter.js
+++ b/app/lib/builder/converter.js
@@ -363,7 +363,7 @@ export function convertFields(fields = [], fn = () => {}) {
 			label: field.label,
 			type: field.type,
 			fields: convertFields(field.fields),
-			options: field.options || {},
+			config: field.config || {},
 			is_static: field.is_static || false
 		})
 	})

--- a/app/lib/builder/ui/Card.svelte
+++ b/app/lib/builder/ui/Card.svelte
@@ -87,7 +87,7 @@
 		}
 	}
 	.Card.minimal .card-body {
-		margin: 0;
+		margin: 0 !important;
 	}
 	button {
 		width: 100%;

--- a/app/lib/builder/views/editor/Layout/ComponentNode.svelte
+++ b/app/lib/builder/views/editor/Layout/ComponentNode.svelte
@@ -378,7 +378,7 @@
 		commit_task = setTimeout(() => manager.commit(), 500)
 	}
 
-	let commit_task = $state<NodeJS.Timeout>()
+	let commit_task
 
 	let mounted = false
 	function dispatch_mount() {

--- a/app/lib/builder/views/editor/Layout/ComponentNode.svelte
+++ b/app/lib/builder/views/editor/Layout/ComponentNode.svelte
@@ -88,7 +88,6 @@
 	const markdown_classes = {}
 
 	async function make_content_editable() {
-		console.log('starting')
 		if (!node?.contentDocument) return
 
 		const doc = node.contentDocument
@@ -302,7 +301,6 @@
 		}
 
 		async function set_editable_link({ element, id, url }) {
-			console.log('set_editable_link', { element, id, url })
 			element.style.outline = '0'
 			element.setAttribute(`data-entry`, id)
 			element.contentEditable = true
@@ -322,23 +320,25 @@
 					})
 				}
 			}
-			element.addEventListener('click', (e) => {
-				e.preventDefault()
-				e.stopPropagation()
-				current_link_element = element
-				current_link_id = id
-				current_link_value = {
-					url: element.href || '',
-					label: element.innerText || '',
-					active: true
-				}
-				editing_link = true
-			}, { capture: true })
+			element.addEventListener(
+				'click',
+				(e) => {
+					e.preventDefault()
+					e.stopPropagation()
+					current_link_element = element
+					current_link_id = id
+					current_link_value = {
+						url: element.href || '',
+						label: element.innerText || '',
+						active: true
+					}
+					editing_link = true
+				},
+				{ capture: true }
+			)
 		}
 
 		async function set_editable_text({ id, element }) {
-			console.log('set_editable_text')
-
 			element.style.outline = '0'
 			element.setAttribute(`data-entry`, id)
 			element.onkeydown = (e) => {
@@ -352,7 +352,6 @@
 				save_edited_value({ id, value: e.target.innerText })
 			}
 			element.onfocus = () => {
-				console.log('focus')
 				dispatch('lock')
 			}
 			element.contentEditable = true
@@ -400,7 +399,7 @@
 			if (link.dataset.entry || link.dataset.key) {
 				return
 			}
-			
+
 			link.onclick = (e) => {
 				e.preventDefault()
 			}
@@ -622,7 +621,7 @@
 	<Dialog.Content class="z-[999] sm:max-w-[500px] pt-12">
 		<ImageField
 			entity={section}
-			field={fields?.find(f => entries?.find(e => e.id === current_image_id)?.field === f.id) || { label: 'Image', key: 'image', type: 'image', config: {} }}
+			field={fields?.find((f) => entries?.find((e) => e.id === current_image_id)?.field === f.id) || { label: 'Image', key: 'image', type: 'image', config: {} }}
 			entry={{
 				value: current_image_value
 			}}
@@ -632,7 +631,7 @@
 			}}
 		/>
 		<div class="flex justify-end gap-2 mt-2">
-			<button 
+			<button
 				onclick={() => {
 					if (active_editor) {
 						// Handle TipTap editor images
@@ -657,7 +656,7 @@
 	<Dialog.Content class="z-[999] sm:max-w-[500px] pt-12 overflow-visible">
 		<LinkField
 			entity={section}
-			field={fields?.find(f => entries?.find(e => e.id === current_link_id)?.field === f.id) || { label: 'Link', key: 'link', type: 'link', config: {} }}
+			field={fields?.find((f) => entries?.find((e) => e.id === current_link_id)?.field === f.id) || { label: 'Link', key: 'link', type: 'link', config: {} }}
 			entry={{
 				value: current_link_value
 			}}
@@ -667,7 +666,7 @@
 			}}
 		/>
 		<div class="flex justify-end gap-2 mt-2">
-			<button 
+			<button
 				onclick={() => {
 					if (active_editor) {
 						// Handle TipTap editor links

--- a/app/lib/builder/views/editor/Layout/ComponentNode.svelte
+++ b/app/lib/builder/views/editor/Layout/ComponentNode.svelte
@@ -118,7 +118,7 @@
 					key: field.key,
 					value: entry.value,
 					type: field.type,
-					options: field.options
+					config: field.config
 				})
 			}
 		}

--- a/app/lib/builder/views/editor/Toolbar.svelte
+++ b/app/lib/builder/views/editor/Toolbar.svelte
@@ -230,9 +230,9 @@
 				<ToolbarButton id="redo" title="Redo" icon="material-symbols:redo" style="border: 0; font-size: 1.5rem;" on:click={redo_change} />
 			{/if} -->
 			<!-- $userRole === 'DEV' -->
-			<!-- {#if true}
+			{#if true}
 				<ToolbarButton icon="clarity:users-solid" on:click={() => (editing_collaborators = true)} />
-			{/if} -->
+			{/if}
 			{@render children?.()}
 			<!-- <LocaleSelector /> -->
 			<ToolbarButton type="primo" icon="entypo:publish" label="Publish" loading={publish.status !== 'standby'} on:click={() => publishing = true} />

--- a/app/lib/builder/views/editor/Toolbar.svelte
+++ b/app/lib/builder/views/editor/Toolbar.svelte
@@ -19,6 +19,7 @@
 	import SitePages from '$lib/builder/views/modal/SitePages/SitePages.svelte'
 	import PageTypeModal from '$lib/builder/views/modal/PageTypeModal/PageTypeModal.svelte'
 	import Collaboration from '$lib/builder/views/modal/Collaboration.svelte'
+	import Deploy from '$lib/components/Modals/Deploy/Deploy.svelte'
 	import { usePublishSite } from '$lib/Publish.svelte'
 	import type { Snippet } from 'svelte'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping'
@@ -69,11 +70,15 @@
 	let editing_pages = $state(false)
 	let editing_page_types = $state(false)
 	let editing_collaborators = $state(false)
+	let publishing = $state(false)
+	let publish_stage = $state('INITIAL')
 
 	// Close all dialogs on navigation
 	onNavigate(() => {
 		editing_pages = false
 		editing_page_types = false
+		publishing = false
+		publish_stage = 'INITIAL'
 	})
 
 	// Hotkey event listeners
@@ -122,6 +127,21 @@
 <Dialog.Root bind:open={editing_collaborators}>
 	<Dialog.Content class="z-[999] max-w-[600px] flex flex-col p-4">
 		<Collaboration />
+	</Dialog.Content>
+</Dialog.Root>
+
+<Dialog.Root bind:open={publishing}>
+	<Dialog.Content class="z-[999] max-w-[500px] flex flex-col p-0">
+		<Deploy 
+			bind:stage={publish_stage}
+			publish_fn={publish.publish}
+			loading={publish.status !== 'standby'}
+			site_host={resolved_site?.host}
+			onClose={() => {
+				publishing = false
+				publish_stage = 'INITIAL'
+			}}
+		/>
 	</Dialog.Content>
 </Dialog.Root>
 
@@ -215,7 +235,7 @@
 			{/if} -->
 			{@render children?.()}
 			<!-- <LocaleSelector /> -->
-			<ToolbarButton type="primo" icon="entypo:publish" label="Publish" loading={publish.status !== 'standby'} on:click={publish.publish} />
+			<ToolbarButton type="primo" icon="entypo:publish" label="Publish" loading={publish.status !== 'standby'} on:click={() => publishing = true} />
 		</div>
 	</div>
 </nav>

--- a/app/lib/builder/views/modal/ImageModal.svelte
+++ b/app/lib/builder/views/modal/ImageModal.svelte
@@ -63,8 +63,7 @@
 	}
 </script>
 
-<div>
-	<div class="image-info">
+<div class="image-modal">
 		{#if loading}
 			<UI.Spinner />
 		{:else}
@@ -112,56 +111,59 @@
 				</label>
 				<label class="image-input">
 					<span>Description</span>
-					<input type="text" value={local_value.alt} />
+					<input 
+						type="text" 
+						value={local_value.alt}
+						oninput={({ target }) => {
+							local_value = {
+								...local_value,
+								alt: target.value
+							}
+						}}
+					/>
 				</label>
 			</div>
 			<footer>
 				<Button type="submit" label="Add Image" />
 			</footer>
 		</form>
-	</div>
 </div>
 
 <style lang="postcss">
-	.image-info {
+	.image-modal {
 		display: flex;
 		flex-direction: column;
-		overflow: hidden;
-		background: #1a1a1a;
-		padding: 0.25rem 0.75rem 0.75rem 0.75rem;
+		gap: 1rem;
 		--Spinner-padding: 3rem;
-	}
-	input {
-		background: var(--color-gray-8);
 	}
 	.image-preview {
 		width: 100%;
-		padding-top: 50%;
+		height: 200px;
 		position: relative;
-		margin-bottom: 0.25rem;
+		border: 2px dashed hsl(var(--border));
+		border-radius: var(--radius);
+		margin-bottom: 1rem;
 
 		.image-upload {
 			flex: 1 1 0%;
 			padding: 1rem;
 			cursor: pointer;
-			position: relative;
+			position: absolute;
+			inset: 0;
 			width: 100%;
 			display: flex;
 			flex-direction: column;
 			align-items: center;
 			justify-content: center;
-			color: var(--color-gray-2);
-			background: var(--color-gray-9);
-			font-weight: 600;
+			color: hsl(var(--muted-foreground));
+			background: transparent;
+			font-weight: 500;
 			text-align: center;
-			position: absolute;
-			inset: 0;
-			opacity: 0.5;
-			transition: opacity, background;
-			transition-duration: 0.1s;
+			transition: all 0.2s;
+			border-radius: var(--radius);
 
 			&:hover {
-				opacity: 0.95;
+				background: hsl(var(--muted) / 0.5);
 			}
 
 			span {
@@ -201,26 +203,36 @@
 	.inputs {
 		display: flex;
 		flex-direction: column;
+		gap: 1rem;
 		width: 100%;
 
 		.image-input {
 			display: flex;
-			align-items: center;
-			font-size: var(--font-size-1);
+			flex-direction: column;
+			gap: 0.5rem;
 			width: 100%;
-			margin-bottom: 0.25rem;
 
 			span {
-				font-weight: 600;
-				padding: 0 0.5rem;
+				font-weight: 500;
+				font-size: 0.875rem;
+				color: hsl(var(--foreground));
 			}
 
 			input {
-				font-size: inherit;
 				flex: 1;
-				padding: 0 0.25rem;
-				outline: 0;
-				border: 0;
+				padding: 0.5rem 0.75rem;
+				border: 1px solid hsl(var(--border));
+				border-radius: var(--radius);
+				background: hsl(var(--background));
+				color: hsl(var(--foreground));
+				font-size: 0.875rem;
+				transition: border-color 0.2s;
+
+				&:focus {
+					outline: none;
+					border-color: hsl(var(--ring));
+					box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+				}
 			}
 		}
 	}

--- a/app/lib/components/Modals/Deploy/Deploy.svelte
+++ b/app/lib/components/Modals/Deploy/Deploy.svelte
@@ -1,42 +1,82 @@
 <script>
 	import Icon from '@iconify/svelte'
 
-	let { stage = $bindable() } = $props()
+	let { stage = $bindable(), publish_fn, loading, site_host, onClose } = $props()
 
 	let error = $state(null)
-	async function publish_site() {
-		// TODO: Implement
+
+	async function handle_publish() {
+		try {
+			error = null
+			await publish_fn()
+			stage = 'PUBLISHED'
+		} catch (err) {
+			error = err.message || 'Failed to publish site'
+			stage = 'ERROR'
+		}
 	}
 
-	stage = 'INITIAL'
-
-	let loading = $state(false)
+	stage = stage || 'INITIAL'
 </script>
 
-<!-- <ModalHeader title="Publish" icon="entypo:publish" /> -->
 <div class="Deploy primo-reset">
 	{#if stage === 'INITIAL'}
 		<div class="container">
-			<p class="description">
-				<!-- TODO: Implement -->
-				Your website is live at
-				<a href="#" target="blank">TODO</a>
-			</p>
+			<h3 class="title">Publish Site</h3>
+			{#if site_host}
+				<p class="description">
+					Your website will be published to
+					<a href="https://{site_host}" target="_blank">{site_host}</a>
+				</p>
+			{:else}
+				<p class="description">Ready to publish your website changes?</p>
+			{/if}
 			<div class="buttons">
-				<button class="primo-button primary" onclick={publish_site}>
+				<button class="primo-button" onclick={onClose}>
+					<span>Cancel</span>
+				</button>
+				<button class="primo-button primary" onclick={handle_publish} disabled={loading}>
 					<Icon icon={loading ? 'line-md:loading-twotone-loop' : 'entypo:publish'} />
-					<span>Publish Changes</span>
+					<span>{loading ? 'Publishing...' : 'Publish Changes'}</span>
 				</button>
 			</div>
 		</div>
 	{:else if stage === 'PUBLISHED'}
-		<p class="description">
-			<!-- TODO: Implement -->
-			Your website changes have been published to
-			<a href="#" target="blank">TODO</a>
-		</p>
+		<div class="container">
+			<h3 class="title">Published Successfully!</h3>
+			<p class="description">
+				Your website changes have been published to
+				{#if site_host}
+					<a href="https://{site_host}" target="_blank">{site_host}</a>
+				{:else}
+					your live site
+				{/if}
+			</p>
+			<div class="buttons">
+				<button class="primo-button primary" onclick={onClose}>
+					<span>Done</span>
+				</button>
+				{#if site_host}
+					<a href="https://{site_host}" target="_blank" class="primo-button">
+						<Icon icon="lucide:external-link" />
+						<span>View Site</span>
+					</a>
+				{/if}
+			</div>
+		</div>
 	{:else if stage === 'ERROR'}
-		<p class="error">{error}</p>
+		<div class="container">
+			<h3 class="title">Publishing Failed</h3>
+			<p class="error">{error}</p>
+			<div class="buttons">
+				<button class="primo-button" onclick={onClose}>
+					<span>Close</span>
+				</button>
+				<button class="primo-button primary" onclick={() => (stage = 'INITIAL')}>
+					<span>Try Again</span>
+				</button>
+			</div>
+		</div>
 	{/if}
 </div>
 
@@ -44,70 +84,79 @@
 	.Deploy.primo-reset {
 		color: white;
 		background: var(--primo-color-black);
-		padding: 1.125rem 1.25rem;
+		padding: 3rem 1.25rem 1.125rem 1.25rem;
 		display: grid;
 		gap: 1rem;
 		width: 100%;
 	}
 	.container {
 		display: grid;
-		gap: 1rem;
 	}
 
-	/* .dns-record {
-		background: var(--color-gray-9);
-		border-radius: var(--primo-border-radius);
-		margin-bottom: 1rem;
-
-		.label {
-			padding-left: 1rem;
-			padding-top: 0.75rem;
-			font-size: 0.875rem;
-			border-bottom: 1px solid #121212;
-			padding-bottom: 0.5rem;
-			display: flex;
-			align-items: center;
-			gap: 0.5rem;
-		}
-
-		.contents {
-			display: grid;
-			grid-template-columns: 1fr 3fr 3fr;
-			gap: 0.5rem;
-			padding: 1rem;
-		}
-	} */
+	.title {
+		font-size: 1.125rem;
+		font-weight: 600;
+		color: white;
+	}
 
 	.error {
 		padding: 0.5rem;
 		background: var(--primo-color-danger);
+		border-radius: 0.25rem;
+		margin: 0.5rem 0;
 	}
 
 	.description {
+		margin-bottom: 2rem;
+		line-height: 1.5;
 		a {
 			text-decoration: underline;
+			color: #70809e;
+		}
+		a:hover {
+			color: white;
 		}
 	}
 
 	.buttons {
 		display: flex;
 		flex-wrap: wrap;
-		align-items: flex-end;
-		gap: 1rem;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 0.75rem;
 	}
 	.primo-button {
 		display: flex;
 		align-items: center;
 		gap: 0.25rem;
-		padding: 7px 16px;
+		padding: 8px 16px;
 		background: var(--primo-color-codeblack);
+		border: 1px solid #333;
 		border-radius: 0.25rem;
-		justify-self: start;
-		/* height: 100%; */
+		color: white;
+		cursor: pointer;
+		text-decoration: none;
+		transition: all 0.2s;
+	}
+	.primo-button:hover {
+		background: #333;
+		border-color: #555;
+	}
+	.primo-button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+	.primo-button:disabled:hover {
+		background: var(--primo-color-codeblack);
+		border-color: #333;
 	}
 	.primo-button.primary {
 		border: 1px solid #70809e;
 		background: transparent;
+	}
+	.primo-button.primary:hover {
+		background: #70809e;
+		border-color: #70809e;
 	}
 	:global(form > label) {
 		flex: 1;

--- a/app/lib/components/Modals/Deploy/Deploy.svelte
+++ b/app/lib/components/Modals/Deploy/Deploy.svelte
@@ -1,6 +1,6 @@
 <script>
 	import Icon from '@iconify/svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 
 	let { stage = $bindable(), publish_fn, loading, site_host, onClose } = $props()
 
@@ -28,7 +28,7 @@
 			{#if site_host}
 				<p class="description">
 					Your website will be published to
-					<a href="{$page.url.protocol}//{site_host}" target="_blank">{site_host}</a>
+					<a href="{page.url.protocol}//{site_host}" target="_blank">{site_host}</a>
 				</p>
 			{:else}
 				<p class="description">Ready to publish your website changes?</p>
@@ -49,7 +49,7 @@
 			<p class="description">
 				Your website changes have been published to
 				{#if site_host}
-					<a href="{$page.url.protocol}//{site_host}" target="_blank">{site_host}</a>
+					<a href="{page.url.protocol}//{site_host}" target="_blank">{site_host}</a>
 				{:else}
 					your live site
 				{/if}
@@ -59,7 +59,7 @@
 					<span>Done</span>
 				</button>
 				{#if site_host}
-					<a href="{$page.url.protocol}//{site_host}" target="_blank" class="primo-button">
+					<a href="{page.url.protocol}//{site_host}" target="_blank" class="primo-button">
 						<Icon icon="lucide:external-link" />
 						<span>View Site</span>
 					</a>

--- a/app/lib/components/Modals/Deploy/Deploy.svelte
+++ b/app/lib/components/Modals/Deploy/Deploy.svelte
@@ -1,5 +1,6 @@
 <script>
 	import Icon from '@iconify/svelte'
+	import { page } from '$app/stores'
 
 	let { stage = $bindable(), publish_fn, loading, site_host, onClose } = $props()
 
@@ -27,7 +28,7 @@
 			{#if site_host}
 				<p class="description">
 					Your website will be published to
-					<a href="https://{site_host}" target="_blank">{site_host}</a>
+					<a href="{$page.url.protocol}//{site_host}" target="_blank">{site_host}</a>
 				</p>
 			{:else}
 				<p class="description">Ready to publish your website changes?</p>
@@ -48,7 +49,7 @@
 			<p class="description">
 				Your website changes have been published to
 				{#if site_host}
-					<a href="https://{site_host}" target="_blank">{site_host}</a>
+					<a href="{$page.url.protocol}//{site_host}" target="_blank">{site_host}</a>
 				{:else}
 					your live site
 				{/if}
@@ -58,7 +59,7 @@
 					<span>Done</span>
 				</button>
 				{#if site_host}
-					<a href="https://{site_host}" target="_blank" class="primo-button">
+					<a href="{$page.url.protocol}//{site_host}" target="_blank" class="primo-button">
 						<Icon icon="lucide:external-link" />
 						<span>View Site</span>
 					</a>

--- a/app/lib/components/Modals/Deploy/Deploy.svelte
+++ b/app/lib/components/Modals/Deploy/Deploy.svelte
@@ -11,7 +11,8 @@
 			await publish_fn()
 			stage = 'PUBLISHED'
 		} catch (err) {
-			error = err.message || 'Failed to publish site'
+			console.error('Publish error:', err)
+			error = err.message || err.toString() || 'Failed to publish site'
 			stage = 'ERROR'
 		}
 	}

--- a/app/lib/converter.js
+++ b/app/lib/converter.js
@@ -434,7 +434,7 @@ export function convertFields(fields = [], fn = () => {}) {
 			label: field.label,
 			type: field.type,
 			fields: convertFields(field.fields),
-			options: field.options || {},
+			config: field.config || {},
 			default: field.default || '',
 			is_static: field.is_static || false
 		}

--- a/app/lib/scramble_ids.js
+++ b/app/lib/scramble_ids.js
@@ -76,11 +76,11 @@ export default function scramble_ids({ site, page_types, symbols, pages, section
     if (new_field.parent) {
       new_field.parent = get_id(new_field.parent)
     }
-    if (new_field.options?.source) {
-      new_field.options.source = get_id(new_field.options.source)
+    if (new_field.config?.source) {
+      new_field.config.source = get_id(new_field.config.source)
     }
-    if (new_field.options?.page_type) {
-      new_field.options.page_type = get_id(new_field.options.page_type)
+    if (new_field.config?.page_type) {
+      new_field.config.page_type = get_id(new_field.config.page_type)
     }
     if (new_field.source) {
       new_field.source = get_id(new_field.source)


### PR DESCRIPTION
## Summary
- Implement missing `save_edited_value` function for persisting field edits
- Fix image editor to use existing ImageField component with proper local state management
- Fix link editor to use existing LinkField component with proper local state management
- Fix event handling to prevent link clicks from opening new tabs when editing
- Update sidebar tab label from "Content" to "Fields" for clarity
- Fix "Manage Fields" link navigation to work like "Manage Blocks"
- Add minimal prop to Content component for cleaner field display in sidebars

## Test plan
- [x] Click on editable images - modal opens with current values
- [x] Click on editable links - modal opens with current values  
- [x] Edit values in modals - changes stay local until "Done" is clicked
- [x] Click "Done" - changes are applied and saved to database
- [x] Links don't open in new tabs when clicked for editing
- [x] "Manage Fields" button navigates correctly
- [x] Sidebar shows "Fields" instead of "Content"

On-page editing now works properly with consistent UI and proper state management.