### PR TITLE
Fix nesting and referencing fields

### DIFF
--- a/app/lib/builder/Primo.svelte
+++ b/app/lib/builder/Primo.svelte
@@ -19,12 +19,10 @@
 
 	let {
 		site,
-		currentPage,
 		toolbar,
 		children
 	}: {
 		site?: ObjectOf<typeof Sites>
-		currentPage?: ObjectOf<typeof Pages>
 		toolbar?: Snippet
 		children?: Snippet
 	} = $props()
@@ -153,7 +151,7 @@
 </script>
 
 <div class="h-screen flex flex-col">
-	<Toolbar {site} {currentPage}>
+	<Toolbar {site}>
 		{@render toolbar?.()}
 	</Toolbar>
 	<PaneGroup direction="horizontal" autoSaveId="page-view" style="height:initial;flex:1;">

--- a/app/lib/builder/components/Content.svelte
+++ b/app/lib/builder/components/Content.svelte
@@ -1,74 +1,16 @@
 <script lang="ts">
-	import * as _ from 'lodash-es'
-	import Card from '../ui/Card.svelte'
-	import { fieldTypes } from '../stores/app'
 	import type { Field } from '$lib/common/models/Field'
-	import { getDirectEntries, type Entity } from '$lib/pocketbase/content'
+	import { type Entity } from '$lib/pocketbase/content'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from './Fields/FieldsContent.svelte'
+	import EntryContent from './Fields/EntryContent.svelte'
 
-	const { minimal, entity, fields, entries, oninput }: { minimal: boolean; entity: Entity; entries: Entry[]; fields: Field[]; oninput: (values: Record<string, unknown>) => void } = $props()
-
-	function check_condition(field: Field) {
-		// TODO: Implement
-		return true
-		// if (!field.condition) return true // has no condition
-
-		// const { field: field_to_compare, value, comparison } = field.condition
-		// const entry = getResolvedEntries(entity_id, field)[0]
-		// if (typeof value === 'string' && is_regex(value)) {
-		// 	const regex = new RegExp(value.slice(1, -1))
-		// 	if (comparison === '=' && regex.test(entry.value)) {
-		// 		return true
-		// 	} else if (comparison === '!=' && !regex.test(entry.value)) {
-		// 		return true
-		// 	}
-		// } else if (comparison === '=' && value === entry.value) {
-		// 	return true
-		// } else if (comparison === '!=' && value !== entry.value) {
-		// 	return true
-		// }
-		// return false
-	}
+	const { entity, fields, entries, oninput }: { entity: Entity; entries: Entry[]; fields: Field[]; oninput: FieldValueHandler } = $props()
 </script>
 
 <div class="Content">
-	{#each fields as field}
-		{@const field_type = $fieldTypes.find((f) => f.id === field.type)}
-		<!-- weird race condition bug, fields is dirty when switching pages w/ sidebar open -->
-		{@const Field_Component = field_type?.component}
-		{@const is_visible = check_condition(field)}
-		{@const is_valid = (field.key || field.type === 'info') && Field_Component}
-		{@const has_child_fields = field.type === 'repeater' || field.type === 'group'}
-		{@const content_entry = getDirectEntries(entity, field, entries)[0]}
-		{#if is_valid && is_visible}
-			<Card {minimal} title={has_child_fields ? field.label : null} icon={field_type?.icon}>
-				<div class="field-item" id="field-{field.key}" class:repeater={field.key === 'repeater'}>
-					<Field_Component
-						{entity}
-						field={{ ...field, label: field.label }}
-						entry={content_entry}
-						onchange={(value) => {
-							oninput({ [field.key]: value })
-						}}
-					/>
-				</div>
-			</Card>
-		{:else if is_valid && is_visible}
-			<Card {minimal} title={has_child_fields ? field.label : null} icon={field_type?.icon}>
-				<div class="field-item" id="field-{field.key}" class:repeater={field.key === 'repeater'}>
-					<Field_Component
-						{entity}
-						{field}
-						entry={content_entry}
-						onchange={(value) => {
-							oninput({ [field.key]: value })
-						}}
-					/>
-				</div>
-			</Card>
-		{:else if is_visible}
-			<p class="empty-description">Field requires a key</p>
-		{/if}
+	{#each fields as field (field.id)}
+		<EntryContent {entity} {field} {fields} {entries} level={0} onchange={oninput} />
 	{:else}
 		<p class="empty-description">
 			<!-- $userRole === 'DEV' -->

--- a/app/lib/builder/components/Fields/EntryContent.svelte
+++ b/app/lib/builder/components/Fields/EntryContent.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import Card from '$lib/builder/ui/Card.svelte'
+	import type { Entry } from '$lib/common/models/Entry'
+	import type { Field } from '$lib/common/models/Field'
+	import { type Entity, getResolvedEntries } from '$lib/pocketbase/content'
+	import type { FieldValueHandler } from './FieldsContent.svelte'
+	import { fieldTypes } from '../../stores/app/index.js'
+	import type { Component } from 'svelte'
+	import Icon from '@iconify/svelte'
+
+	let {
+		entity,
+		parent,
+		field,
+		fields,
+		entries,
+		level,
+		onchange
+	}: {
+		entity: Entity
+		parent?: Entry
+		field: Field
+		fields: Field[]
+		entries: Entry[]
+		level: number
+		onchange: FieldValueHandler
+	} = $props()
+
+	const field_type = $derived($fieldTypes.find((ft) => ft.id === field.type))
+	const Field_Component = $derived(
+		field_type?.component as
+			| Component<{
+					entity: Entity
+					field: Field
+					entry?: Entry
+					fields: Field[]
+					entries: Entry[]
+					onchange: FieldValueHandler
+					level: number
+			  }>
+			| undefined
+	)
+
+	// TODO: Implement conditions
+	const is_visible = true
+</script>
+
+{#if !Field_Component}
+	<!-- TODO: Improve the error message -->
+	<span>Field type for the field is not found!</span>
+{:else if is_visible}
+	{@const [entry] = getResolvedEntries(entity, field, entries).filter((entry) => (parent ? entry.parent === parent.id : !entry.parent))}
+	{@const title = ['repeater', 'group'].includes(field.type) ? field.label : null}
+	{@const icon = undefined}
+	{#if field.type === 'site-field' || field.type === 'page-field'}
+		<div class="dynamic-header">
+			{#if field.type === 'site-field'}
+				<Icon icon="gg:website" />
+				<span>Site Content</span>
+			{:else if field.type === 'page-field'}
+				<!-- {@const content_entry = getDirectEntries(entity, field, entries)[0]} -->
+				<!-- <Icon icon={content_entry?.value.page.page_type.icon} /> -->
+				<span>Page Content</span>
+			{/if}
+		</div>
+	{/if}
+	<Card {title} {icon}>
+		<Field_Component {entity} {field} {fields} {entries} {entry} {level} {onchange} />
+	</Card>
+	<!-- TODO: $userRole === 'DEV' -->
+{:else if !is_visible}
+	<div class="hidden-field">
+		<Icon icon="mdi:hidden" />
+		<span>This field will be hidden from content editors</span>
+	</div>
+{/if}
+
+<style>
+	.dynamic-header {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.25rem;
+		border-bottom: 1px solid var(--color-gray-9);
+		padding-block: 0.5rem;
+		font-size: 0.75rem;
+	}
+	.hidden-field {
+		padding: 1rem;
+		color: var(--color-gray-2);
+		font-size: 0.875rem;
+	}
+</style>

--- a/app/lib/builder/components/Fields/FieldItem.svelte
+++ b/app/lib/builder/components/Fields/FieldItem.svelte
@@ -37,9 +37,9 @@
 		top_level?: boolean
 		create_field?: (parentId?: string) => void
 		onchange: (details: { id: string; data: Partial<Field> }) => void
-		onduplicate: () => void
-		ondelete: () => void
-		onmove: (direction: 'up' | 'down') => void
+		onduplicate: (id: string) => void
+		ondelete: (id: string) => void
+		onmove: (id: string, direction: 'up' | 'down') => void
 	} = $props()
 
 	const host = $derived(page.url.host)
@@ -220,10 +220,10 @@
 						<button onclick={add_condition}>
 							<Icon icon="mdi:show" />
 						</button>
-						<button onclick={onduplicate}>
+						<button onclick={() => onduplicate(field.id)}>
 							<Icon icon="bxs:duplicate" />
 						</button>
-						<button class="delete" onclick={ondelete}>
+						<button class="delete" onclick={() => ondelete(field.id)}>
 							<Icon icon="ic:outline-delete" />
 						</button>
 					{:else}
@@ -233,12 +233,12 @@
 								{
 									label: 'Move up',
 									icon: 'material-symbols:arrow-circle-up-outline',
-									on_click: () => onmove('up')
+									on_click: () => onmove(field.id, 'up')
 								},
 								{
 									label: 'Move down',
 									icon: 'material-symbols:arrow-circle-down-outline',
-									on_click: () => onmove('down')
+									on_click: () => onmove(field.id, 'down')
 								},
 								...(has_condition
 									? []
@@ -255,13 +255,13 @@
 								{
 									label: 'Duplicate',
 									icon: 'bxs:duplicate',
-									on_click: () => onduplicate()
+									on_click: () => onduplicate(field.id)
 								},
 								{
 									label: 'Delete',
 									icon: 'ic:outline-delete',
 									is_danger: true,
-									on_click: () => ondelete()
+									on_click: () => ondelete(field.id)
 								}
 							]}
 							placement="bottom-end"
@@ -296,10 +296,10 @@
 							<button onclick={add_condition}>
 								<Icon icon="mdi:show" />
 							</button>
-							<button onclick={onduplicate}>
+							<button onclick={() => onduplicate(field.id)}>
 								<Icon icon="bxs:duplicate" />
 							</button>
-							<button class="delete" onclick={ondelete}>
+							<button class="delete" onclick={() => ondelete(field.id)}>
 								<Icon icon="ic:outline-delete" />
 							</button>
 						{:else}
@@ -309,12 +309,12 @@
 									{
 										label: 'Move up',
 										icon: 'material-symbols:arrow-circle-up-outline',
-										on_click: () => onmove('up')
+										on_click: () => onmove(field.id, 'up')
 									},
 									{
 										label: 'Move down',
 										icon: 'material-symbols:arrow-circle-down-outline',
-										on_click: () => onmove('down')
+										on_click: () => onmove(field.id, 'down')
 									},
 									...(has_condition
 										? []
@@ -330,13 +330,13 @@
 									{
 										label: 'Duplicate',
 										icon: 'bxs:duplicate',
-										on_click: () => onduplicate()
+										on_click: () => onduplicate(field.id)
 									},
 									{
 										label: 'Delete',
 										icon: 'ic:outline-delete',
 										is_danger: true,
-										on_click: () => ondelete()
+										on_click: () => ondelete(field.id)
 									}
 								]}
 								placement="bottom-end"
@@ -396,10 +396,10 @@
 							<button onclick={add_condition}>
 								<Icon icon="mdi:show" />
 							</button>
-							<button onclick={onduplicate}>
+							<button onclick={() => onduplicate(field.id)}>
 								<Icon icon="bxs:duplicate" />
 							</button>
-							<button class="delete" onclick={ondelete}>
+							<button class="delete" onclick={() => ondelete(field.id)}>
 								<Icon icon="ic:outline-delete" />
 							</button>
 						{:else}
@@ -409,12 +409,12 @@
 									{
 										label: 'Move up',
 										icon: 'material-symbols:arrow-circle-up-outline',
-										on_click: () => onmove('up')
+										on_click: () => onmove(field.id, 'up')
 									},
 									{
 										label: 'Move down',
 										icon: 'material-symbols:arrow-circle-down-outline',
-										on_click: () => onmove('down')
+										on_click: () => onmove(field.id, 'down')
 									},
 									...(has_condition
 										? []
@@ -430,13 +430,13 @@
 									{
 										label: 'Duplicate',
 										icon: 'bxs:duplicate',
-										on_click: () => onduplicate()
+										on_click: () => onduplicate(field.id)
 									},
 									{
 										label: 'Delete',
 										icon: 'ic:outline-delete',
 										is_danger: true,
-										on_click: () => ondelete()
+										on_click: () => ondelete(field.id)
 									}
 								]}
 								placement="bottom-end"
@@ -451,7 +451,6 @@
 		{#if field.type === 'select'}
 			<SelectField
 				{field}
-				{level}
 				on:input={(event) => {
 					onchange({ id: field.id, data: event.detail })
 				}}
@@ -485,7 +484,7 @@
 			/>
 		{/if}
 		{#if field.type === 'page-list'}
-			<PageListField {field} oninput={onchange} />
+			<PageListField {field} />
 		{/if}
 		{#if field.config?.condition}
 			<Condition

--- a/app/lib/builder/components/Fields/FieldsContent.svelte
+++ b/app/lib/builder/components/Fields/FieldsContent.svelte
@@ -1,13 +1,59 @@
+<script lang="ts" module>
+	/**
+	 * Map of field key to object keyed by index specifying value and optionally sub-values.
+	 */
+	export type FieldValueMap = Record<string, Record<number, { value: unknown; subValues?: FieldValueMap }>>
+
+	/**
+	 * Handler used when reporting change of field value.
+	 */
+	export type FieldValueHandler = (values: FieldValueMap) => void
+
+	export function setFieldEntries(options: {
+		fields?: Field[]
+		entries?: Entry[]
+		updateEntry: (id: string, data: Partial<Entry>) => Entry
+		createEntry: (data: Omit<Entry, 'id'>) => Entry
+		values: FieldValueMap
+		parent?: Entry
+	}) {
+		const { fields, entries, updateEntry, createEntry, values, parent } = options
+		console.log(values)
+		for (const [key, items] of Object.entries(values)) {
+			for (const index in items) {
+				const field = fields?.find((field) => field.key === key && (parent ? field.parent === parent?.field : !field.parent))
+				if (!field) {
+					continue
+				}
+
+				let entry = entries?.find((entry) => entry.field === field?.id && (parent ? entry.parent === parent?.id : !entry.parent) && entry.index === +index)
+				if (entry) {
+					console.log('update', field.id, entry.id, items[index].value)
+					entry = updateEntry(entry.id, { value: items[index].value })
+				} else {
+					console.log('create', field.id, items[index].value)
+					entry = createEntry({ field: field.id, parent: parent?.id, index: +index, locale: 'en', value: items[index].value })
+				}
+
+				if (items[index].subValues) {
+					setFieldEntries({ ...options, values: items[index].subValues, parent: entry })
+				}
+			}
+		}
+	}
+</script>
+
 <script lang="ts">
 	import Icon from '@iconify/svelte'
 	import * as _ from 'lodash-es'
 	import FieldItem from './FieldItem.svelte'
 	import { fieldTypes } from '../../stores/app/index.js'
-	import Card from '../../ui/Card.svelte'
 	import { mod_key_held } from '../../stores/app/misc.js'
 	import type { Field } from '$lib/common/models/Field'
-	import { getDirectEntries, getResolvedEntries, type Entity } from '$lib/pocketbase/content'
+	import type { Entity } from '$lib/pocketbase/content'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { Component } from 'svelte'
+	import EntryContent from './EntryContent.svelte'
 
 	let {
 		entity,
@@ -16,55 +62,33 @@
 		create_field,
 		oninput,
 		onchange,
-		ondelete,
-		onadd
+		ondelete
 	}: {
 		entity: Entity
 		fields: Field[]
 		entries: Entry[]
 		create_field: (parentId?: string) => void
-		oninput: (values: Record<string, unknown>) => void
+		oninput: FieldValueHandler
 		onchange: (details: { id: string; data: Partial<Field> }) => void
 		ondelete: (field_id: string) => void
-		onadd?: (details: { parent: string; index: number; subfields: Field[] }) => void
 	} = $props()
 
 	function get_component(field: Field) {
 		const fieldType = $fieldTypes.find((ft) => ft.id === field.type)
 		if (fieldType) {
-			return fieldType.component
+			return fieldType.component as Component<{
+				entity: Entity
+				field: Field
+				entry?: Entry
+				fields: Field[]
+				entries: Entry[]
+				onchange: FieldValueHandler
+				level: number
+			}>
 		} else {
 			console.warn(`Field type '${field.type}' no longer exists, removing '${field.label}' field`)
 			return null
 		}
-	}
-
-	function check_condition(field: Field) {
-		return true // TODO: Implement
-
-		// if (!field.condition) return true // has no condition
-
-		// const { field: field_to_check, value, comparison } = field.condition
-
-		// // TODO: ensure correct field (considering repeaters)
-		// const content_entry = get_direct_entries(entity_id, field_to_check)?.[0]
-		// if (!content_entry) {
-		// 	// comparable entry is a non-matching data field
-		// 	// TODO: add UI to conditional component that says "this field will show when data field is irrelevant"
-		// 	return true
-		// } else if (comparison === '=' && value === content_entry.value) {
-		// 	return true
-		// } else if (comparison === '!=' && value !== content_entry.valuerable_value) {
-		// 	return true
-		// } else if (typeof value === 'string' && is_regex(value)) {
-		// 	const regex = new RegExp(value.slice(1, -1))
-		// 	if (comparison === '=' && regex.test(content_entry.value)) {
-		// 		return true
-		// 	} else if (comparison === '!=' && !regex.test(content_entry.value)) {
-		// 		return true
-		// 	}
-		// }
-		// return false
 	}
 
 	// TABS
@@ -91,10 +115,8 @@
 
 <div class="Fields">
 	{#each (fields || []).filter((f) => !f.parent || f.parent === '') as field (field.id)}
-		{@const Field_Component = get_component(field)}
 		<!-- TODO: $userRole === 'DEV' -->
 		{@const active_tab = selected_tabs[field.id] || 'field'}
-		{@const is_visible = check_condition(field)}
 		<div class="entries-item">
 			<!-- TODO: hotkeys for tab switching  -->
 			<!-- TODO: $userRole === 'DEV' -->
@@ -128,7 +150,6 @@
 							}
 						}}
 					>
-						<Icon icon={is_visible ? undefined : 'mdi:hide'} />
 						{#if field.type === 'repeater'}
 							<span>Entries</span>
 						{:else}
@@ -145,7 +166,7 @@
 							{fields}
 							{create_field}
 							{onchange}
-							ondelete={() => ondelete(field.id)}
+							{ondelete}
 							onduplicate={() => {
 								// TODO: Implement duplicate
 							}}
@@ -155,50 +176,7 @@
 						/>
 					</div>
 				{:else if active_tab === 'entry'}
-					{#if is_visible}
-						{#if field.type === 'site-field' || field.type === 'page-field'}
-							{@const source_entry = getResolvedEntries(entity, field, entries)[0]}
-							{@const title = ['repeater', 'group'].includes(field.type) ? field.label : null}
-							{@const icon = undefined}
-							<div class="dynamic-header">
-								{#if field.type === 'site-field'}
-									<Icon icon="gg:website" />
-									<span>Site Content</span>
-								{:else if field.type === 'page-field'}
-									{@const content_entry = getDirectEntries(entity, field, entries)[0]}
-									<!-- <Icon icon={content_entry?.value.page.page_type.icon} /> -->
-									<span>Page Content</span>
-								{/if}
-							</div>
-							<Card {title} {icon}>
-								<Field_Component {entity} {field} {fields} {entries} entry={source_entry} id={source_entry?.id} onchange={(value) => oninput({ [field.key]: value })} />
-							</Card>
-						{:else}
-							{@const content_entry = getDirectEntries(entity, field, entries)[0]}
-							{@const title = ['repeater', 'group'].includes(field.type) ? field.label : null}
-							{@const icon = undefined}
-							<Card {title} {icon}>
-								<Field_Component
-									{entity}
-									{field}
-									{fields}
-									{entries}
-									entry={content_entry}
-									id={content_entry?.id}
-									onchange={(value) => oninput({ [field.key]: value })}
-									on:add={(event) => {
-										if (onadd) onadd(event.detail)
-									}}
-								/>
-							</Card>
-						{/if}
-						<!-- TODO: $userRole === 'DEV' -->
-					{:else if !is_visible}
-						<div class="hidden-field">
-							<Icon icon="mdi:hidden" />
-							<span>This field will be hidden from content editors</span>
-						</div>
-					{/if}
+					<EntryContent {entity} {field} {fields} {entries} level={0} onchange={oninput} />
 				{/if}
 			</div>
 		</div>
@@ -227,20 +205,6 @@
 		overflow-y: auto;
 		place-content: flex-start;
 		justify-content: stretch;
-	}
-	.dynamic-header {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.25rem;
-		border-bottom: 1px solid var(--color-gray-9);
-		padding-block: 0.5rem;
-		font-size: 0.75rem;
-	}
-	.hidden-field {
-		padding: 1rem;
-		color: var(--color-gray-2);
-		font-size: 0.875rem;
 	}
 	.entries-item {
 		display: grid;

--- a/app/lib/builder/components/Fields/PageField.svelte
+++ b/app/lib/builder/components/Fields/PageField.svelte
@@ -7,7 +7,7 @@
 
 	const host = $derived(page.url.host)
 	const site = $derived(Sites.list({ filter: `host = "${host}"` })?.[0])
-	const { field }: { entity_id: string; field: PageField } = $props()
+	const { field }: { field: PageField } = $props()
 
 	const dispatch = createEventDispatcher()
 

--- a/app/lib/builder/components/Fields/PageFieldField.svelte
+++ b/app/lib/builder/components/Fields/PageFieldField.svelte
@@ -7,7 +7,7 @@
 
 	const host = $derived(page.url.host)
 	const site = $derived(Sites.list({ filter: `host = "${host}"` })?.[0])
-	const { field }: { entity_id: string; field: PageFieldField } = $props()
+	const { field }: { field: PageFieldField } = $props()
 
 	const dispatch = createEventDispatcher()
 

--- a/app/lib/builder/components/Fields/PageListField.svelte
+++ b/app/lib/builder/components/Fields/PageListField.svelte
@@ -6,7 +6,7 @@
 
 	const host = $derived(page.url.host)
 	const site = $derived(Sites.list({ filter: `host = "${host}"` })?.[0])
-	const { field }: { entity_id: string; field: PageListField } = $props()
+	const { field }: { field: PageListField } = $props()
 </script>
 
 <div class="PagesField">

--- a/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
@@ -21,6 +21,7 @@
 	import DropZone from '$lib/components/DropZone.svelte'
 	import { exportSymbol, importSiteSymbol } from '$lib/builder/utils/symbolImportExport'
 	import { Button } from '$lib/components/ui/button'
+	import { setFieldEntries } from '../Fields/FieldsContent.svelte'
 
 	const host = $derived(page.url.host)
 	const site = $derived(Sites.list({ filter: `host = "${host}"` })?.[0])
@@ -293,20 +294,13 @@
 							})
 						}}
 						oninput={(values) => {
-							for (const [key, value] of Object.entries(values)) {
-								const field = fields?.find((field) => field.key === key)
-								if (!field) {
-									continue
-								}
-
-								const entry = entries?.find((entry) => entry.field === field?.id)
-								if (entry) {
-									PageTypeEntries.update(entry.id, { value })
-								} else {
-									PageTypeEntries.create({ field: field.id, locale: 'en', value })
-								}
-							}
-
+							setFieldEntries({
+								fields,
+								entries,
+								updateEntry: PageTypeEntries.update,
+								createEntry: PageTypeEntries.create,
+								values
+							})
 							clearTimeout(commit_task)
 							commit_task = setTimeout(() => manager.commit(), 500)
 						}}

--- a/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
@@ -16,6 +16,7 @@
 	import { PageTypes, Sites, Pages, PageEntries, manager } from '$lib/pocketbase/collections'
 	import { SiteSymbols } from '$lib/pocketbase/collections'
 	import { getContext } from 'svelte'
+	import { setFieldEntries } from '../Fields/FieldsContent.svelte'
 
 	let active_tab = $state((browser && localStorage.getItem('page-tab')) || 'BLOCKS')
 
@@ -126,20 +127,13 @@
 							fields={page_type_fields}
 							entries={page_entries}
 							oninput={(values) => {
-								for (const [key, value] of Object.entries(values)) {
-									const field = page_type_fields?.find((field) => field.key === key)
-									if (!field) {
-										continue
-									}
-
-									const entry = page_entries?.find((entry) => entry.field === field?.id)
-									if (entry) {
-										PageEntries.update(entry.id, { value })
-									} else {
-										PageEntries.create({ page: page.id, field: field.id, locale: 'en', value })
-									}
-								}
-
+								setFieldEntries({
+									fields: page_type_fields,
+									entries: page_entries,
+									updateEntry: PageEntries.update,
+									createEntry: (data) => PageEntries.create({ ...data, page: page.id }),
+									values
+								})
 								clearTimeout(commit_task)
 								commit_task = setTimeout(() => manager.commit(), 500)
 							}}
@@ -169,20 +163,13 @@
 					fields={page_type_fields}
 					entries={page_entries}
 					oninput={(values) => {
-						for (const [key, value] of Object.entries(values)) {
-							const field = page_type_fields?.find((field) => field.key === key)
-							if (!field) {
-								continue
-							}
-
-							const entry = page_entries?.find((entry) => entry.field === field?.id)
-							if (entry) {
-								PageEntries.update(entry.id, { value })
-							} else {
-								PageEntries.create({ page: page.id, field: field.id, locale: 'en', value })
-							}
-						}
-
+						setFieldEntries({
+							fields: page_type_fields,
+							entries: page_entries,
+							updateEntry: PageEntries.update,
+							createEntry: (data) => PageEntries.create({ ...data, page: page.id }),
+							values
+						})
 						clearTimeout(commit_task)
 						commit_task = setTimeout(() => manager.commit(), 500)
 					}}

--- a/app/lib/builder/field-types/IconField.svelte
+++ b/app/lib/builder/field-types/IconField.svelte
@@ -5,9 +5,21 @@
 	import type { Entity } from '$lib/pocketbase/content'
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange, search_query = '' }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: string) => void; search_query?: string } = $props()
-	
+	let {
+		field,
+		entry,
+		onchange,
+		search_query = ''
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+		search_query?: string
+	} = $props()
+
 	const value = $derived(entry?.value ?? '')
 
 	let searched = $state(false)
@@ -15,7 +27,7 @@
 	$effect(() => {
 		if (!getIcon(value) && !value.startsWith('<svg')) {
 			// reset value when invalid (i.e. when switching field type)
-			onchange('')
+			onchange({ [field.key]: { 0: { value: '' } } })
 		} else if (getIcon(value)) {
 			// convert icon-id to icon-svg
 			select_icon(value)
@@ -45,7 +57,7 @@
 	async function select_icon(icon) {
 		// delete icon
 		if (!icon) {
-			onchange('')
+			onchange({ [field.key]: { 0: { value: '' } } })
 			return
 		}
 
@@ -54,7 +66,7 @@
 		if (icon_data) {
 			const { attributes } = buildIcon(icon_data)
 			const svg = `<svg xmlns="http://www.w3.org/2000/svg" data-key="${field.key}" data-icon="${icon}" aria-hidden="true" role="img" height="${attributes.height}" width="${attributes.width}" viewBox="${attributes.viewBox}" preserveAspectRatio="${attributes.preserveAspectRatio}">${icon_data.body}</svg>`
-			onchange(svg)
+			onchange({ [field.key]: { value: svg } })
 		}
 	}
 </script>

--- a/app/lib/builder/field-types/ImageField.svelte
+++ b/app/lib/builder/field-types/ImageField.svelte
@@ -4,15 +4,26 @@
 	import TextInput from '../ui/TextInput.svelte'
 	import Spinner from '../ui/Spinner.svelte'
 	import imageCompression from 'browser-image-compression'
-	import type { ImageField } from '$lib/common/models/fields/ImageField'
-	import { getDirectEntries, type Entity } from '$lib/pocketbase/content'
+	import type { Entity } from '$lib/pocketbase/content'
+	import type { Field } from '$lib/common/models/Field'
+	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
 	const default_value = {
 		alt: '',
 		url: ''
 	}
 
-	const { entity, field, entry: passedEntry, onchange }: { entity: Entity; field: ImageField; entry?: any; onchange: (value: any) => void } = $props()
+	const {
+		field,
+		entry: passedEntry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+	} = $props()
 	const entry = $derived(passedEntry || { value: default_value })
 
 	async function upload_image(image) {
@@ -84,12 +95,12 @@
 			{/if}
 		</div>
 		<div class="inputs">
-			<TextInput value={entry.value.alt} label="Description" oninput={(alt) => onchange({ ...entry.value, alt })} />
+			<TextInput value={entry.value.alt} label="Description" oninput={(alt) => onchange({ [field.key]: { 0: { value: { ...entry.value, alt } } } })} />
 			<TextInput
 				value={entry.value.url}
 				label="URL"
 				oninput={(value) => {
-					onchange({ ...entry.value, url: value })
+					onchange({ [field.key]: { 0: { value: { ...entry.value, url: value } } } })
 				}}
 			/>
 		</div>

--- a/app/lib/builder/field-types/Link.svelte
+++ b/app/lib/builder/field-types/Link.svelte
@@ -7,8 +7,9 @@
 	import { page } from '$app/state'
 	import { Sites } from '$lib/pocketbase/collections'
 	import { type Entity } from '$lib/pocketbase/content'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	const { entity, field, entry: passedEntry, onchange }: { entity: Entity; field: LinkField; entry?: any; onchange: (value: any) => void } = $props()
+	const { entity, field, entry: passedEntry, onchange }: { entity: Entity; field: LinkField; entry?: any; onchange: FieldValueHandler } = $props()
 
 	const default_value = {
 		label: '',
@@ -41,7 +42,7 @@
 		<UI.TextInput
 			label={field.label}
 			oninput={(text) => {
-				onchange({ ...entry.value, label: text })
+				onchange({ [field.key]: { 0: { value: { ...entry.value, label: text } } } })
 			}}
 			value={entry.value.label}
 			id="page-label"
@@ -66,14 +67,14 @@
 						const page = selectable_pages.find((p) => p.id === pageId)
 						if (page) {
 							selected_page = page
-							onchange({ ...entry.value, page: page.id, url: get_page_url(page) })
+							onchange({ [field.key]: { 0: { value: { ...entry.value, page: page.id, url: get_page_url(page) } } } })
 						}
 					}}
 				/>
 			{:else}
 				<UI.TextInput
 					oninput={(text) => {
-						onchange({ ...entry.value, url: text })
+						onchange({ [field.key]: { 0: { value: { ...entry.value, url: text } } } })
 					}}
 					value={entry.value.url}
 					type="url"

--- a/app/lib/builder/field-types/Markdown.svelte
+++ b/app/lib/builder/field-types/Markdown.svelte
@@ -5,8 +5,18 @@
 	import type { Entity } from '$lib/pocketbase/content'
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: {html: string, markdown: string}) => void } = $props()
+	let {
+		field,
+		entry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+	} = $props()
 
 	// ensure value is correct shape
 	let value = $derived.by(() => {
@@ -34,7 +44,7 @@
 
 	async function parseContent(markdown) {
 		const html = await convert_markdown_to_html(markdown)
-		onchange({ html, markdown })
+		onchange({ [field.key]: { 0: { html, markdown } } })
 	}
 </script>
 

--- a/app/lib/builder/field-types/Number.svelte
+++ b/app/lib/builder/field-types/Number.svelte
@@ -3,12 +3,22 @@
 	import type { Entity } from '$lib/pocketbase/content'
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: number) => void } = $props()
+	let {
+		field,
+		entry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+	} = $props()
 </script>
 
 <div>
-	<UI.TextInput {...field} value={entry?.value ?? ''} oninput={(text) => onchange(parseFloat(text) || 0)} type="number" />
+	<UI.TextInput {...field} value={entry?.value ?? ''} oninput={(text) => onchange({ [field.key]: { 0: parseFloat(text) || 0 } })} type="number" />
 </div>
 
 <style lang="postcss">

--- a/app/lib/builder/field-types/PageField.svelte
+++ b/app/lib/builder/field-types/PageField.svelte
@@ -5,8 +5,9 @@
 	import { Sites } from '$lib/pocketbase/collections'
 	import type { Entity } from '$lib/pocketbase/content.js'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	const { entity, field, entry, onchange }: { entity: Entity; field: PageField; entry?: Entry; onchange?: (value: any) => void } = $props()
+	const { entity, field, entry, onchange }: { entity: Entity; field: PageField; entry?: Entry; onchange: FieldValueHandler } = $props()
 	const host = $derived(page.url.host)
 	const site = $derived(Sites.list({ filter: `host = "${host}"` })?.[0])
 	const selectable_pages = $derived.by(() => {
@@ -25,9 +26,7 @@
 			label: page?.name
 		}))}
 		on:input={({ detail }) => {
-			if (onchange) {
-				onchange(detail)
-			}
+			onchange({ [field.key]: { 0: { value: detail } } })
 		}}
 		fullwidth={true}
 	/>

--- a/app/lib/builder/field-types/RepeaterField.svelte
+++ b/app/lib/builder/field-types/RepeaterField.svelte
@@ -4,42 +4,67 @@
 	import('../libraries/pluralize').then((mod) => pluralize.set(mod.default))
 </script>
 
-<script>
-	import { flip } from 'svelte/animate'
-	import { find as _find, chain as _chain, cloneDeep as _cloneDeep } from 'lodash-es'
+<script lang="ts">
 	import Icon from '@iconify/svelte'
-	import { createEventDispatcher, onDestroy, tick } from 'svelte'
+	import { onDestroy } from 'svelte'
 	import RepeaterFieldItem from './RepeaterFieldItem.svelte'
 
 	import * as idb from 'idb-keyval'
-	const dispatch = createEventDispatcher()
+	import type { Entry } from '$lib/common/models/Entry'
+	import type { Entity } from '$lib/pocketbase/content'
+	import type { Field } from '$lib/common/models/Field'
+	import { get_empty_value } from '../utils'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	/**
-	 * @typedef {Object} Props
-	 * @property {any} id
-	 * @property {any} field
-	 * @property {any} fields
-	 * @property {any} entries
-	 * @property {number} [level]
-	 * @property {boolean} [show_label]
-	 */
+	let {
+		entity,
+		field,
+		fields,
+		entries,
+		onchange,
+		level
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		fields: Field[]
+		entries: Entry[]
+		onchange: FieldValueHandler
+		level: number
+	} = $props()
 
-	/** @type {Props} */
-	let { id, field, fields, entries, level = 0, show_label = false, oninput } = $props()
-
+	let repeater_entries = $derived(entries?.filter((r) => r.field === field.id).sort((a, b) => a.index - b.index))
 	let subfields = $derived(fields?.filter((f) => f.parent === field.id).sort((a, b) => a.index - b.index))
-	let repeater_entries = $derived(entries?.filter((r) => r.parent === id))
 
-	let repeater_item_just_created = $state(null) // to autofocus on creation
-	async function add_item() {
-		const n_sibling_entries = repeater_entries.length
-		repeater_item_just_created = n_sibling_entries
-		await tick()
-		dispatch('add', { parent: field.id, index: repeater_entries.length, subfields })
-		visibleRepeaters[`${field.key}-${repeater_entries.length - 1}`] = true
+	let repeater_item_just_created = $state<number | null>(null) // to autofocus on creation
+	function add_item() {
+		repeater_item_just_created = 0
+		for (const entry of repeater_entries) {
+			if (entry.index >= repeater_item_just_created) {
+				repeater_item_just_created = entry.index + 1
+			}
+		}
+
+		onchange({
+			[field.key]: {
+				[repeater_item_just_created]: {
+					value: null,
+					subValues: Object.fromEntries(
+						subfields.map((subfield) => [
+							subfield.key,
+							{
+								0: { value: get_empty_value(subfield) }
+							}
+						])
+					)
+				}
+			}
+		})
+
+		visibleRepeaters[`${field.key}-${repeater_item_just_created}`] = true
 	}
 
-	let visibleRepeaters = $state({})
+	let visibleRepeaters = $state<Record<string, boolean>>({})
 
 	idb.get(field.id).then((res) => {
 		if (res) {
@@ -49,8 +74,11 @@
 
 	onDestroy(() => {
 		// save visible repeaters
-		idb.set(field.id, _cloneDeep(visibleRepeaters))
+		idb.set(field.id, { ...visibleRepeaters })
 	})
+
+	// TODO: Handle these
+	let show_label = false
 
 	let hover_index = $state(null)
 	let hover_position = $state(null)
@@ -61,21 +89,23 @@
 		<p class="primo--field-label">{field.label}</p>
 	{/if}
 	<ul class="fields">
-		{#each repeater_entries?.sort((a, b) => a.index - b.index) as repeater_item, index (repeater_item.id + '-' + index)}
+		{#each repeater_entries as entry (entry.id)}
+			{@const index = entry.index}
 			{@const subfield_id = `${field.key}-${index}`}
 			{@const autofocus = index === repeater_item_just_created}
 			{@const hovering = hover_index === index}
 			<li>
 				<RepeaterFieldItem
-					{repeater_item}
+					{entity}
 					{field}
+					{entry}
 					{index}
-					{subfields}
 					{fields}
+					{subfields}
 					{entries}
 					{level}
 					{autofocus}
-					{oninput}
+					{onchange}
 					is_visible={visibleRepeaters[subfield_id]}
 					on:toggle={() => (visibleRepeaters[subfield_id] = !visibleRepeaters[subfield_id])}
 					on:hover={({ detail }) => {

--- a/app/lib/builder/field-types/RepeaterFieldItem.svelte
+++ b/app/lib/builder/field-types/RepeaterFieldItem.svelte
@@ -4,21 +4,25 @@
 	import('../libraries/pluralize').then((mod) => pluralize.set(mod.default))
 </script>
 
-<script>
-	import { createEventDispatcher } from 'svelte'
+<script lang="ts">
+	import { createEventDispatcher, type Component } from 'svelte'
 	import * as _ from 'lodash-es'
 	import { onMount } from 'svelte'
 	import Icon from '@iconify/svelte'
-	import { is_regex } from '../utils'
-	import { fieldTypes } from '../stores/app'
+	import type { Field } from '$lib/common/models/Field'
+	import type { Entry } from '$lib/common/models/Entry'
+	import { getResolvedEntries, type Entity } from '$lib/pocketbase/content'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
+	import EntryContent from '../components/Fields/EntryContent.svelte'
 
 	const dispatch = createEventDispatcher()
 
 	let {
-		repeater_item,
+		entity,
 		field,
-		subfields,
+		entry,
 		fields,
+		subfields,
 		entries,
 		index,
 		level,
@@ -26,73 +30,50 @@
 		autofocus,
 		hovering,
 		hover_position,
-		oninput = /** @type {(val: {id: string, data: any}) => void} */ () => {}
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry: Entry
+		fields: Field[]
+		subfields: Field[]
+		entries: Entry[]
+		index: number
+		level: number
+		is_visible: boolean
+		autofocus: boolean
+		hovering: boolean
+		hover_position: 'top' | 'bottom'
+		onchange: FieldValueHandler
 	} = $props()
 
-	function getFieldComponent(subfield) {
-		const field = _.find($fieldTypes, ['id', subfield.type])
-		return field ? field.component : null
-	}
-
-	function get_content_entry(subfield) {
-		const entry = entries.find((e) => e.field === subfield.id && e.parent === repeater_item.id)
-		return entry
-	}
-
-	function get_image(repeater_item) {
-		const [first_subfield] = subfields
+	function get_image() {
+		const [first_subfield] = fields
 		if (first_subfield && first_subfield.type === 'image') {
-			const content_entry = entries.find((r) => r.field === first_subfield.id && r.parent === repeater_item.id)
-			return content_entry?.value?.url
+			const [ent] = getResolvedEntries(entity, first_subfield, entries).filter((ent) => ent.parent === entry.id)
+			return ent?.value?.url
 		} else return null
 	}
 
-	function get_icon(repeater_item) {
-		const [first_subfield] = subfields
+	function get_icon() {
+		const [first_subfield] = fields
 		if (first_subfield && first_subfield.type === 'icon') {
-			const content_entry = entries.find((r) => r.field === first_subfield.id && r.parent === repeater_item.id)
-			return content_entry?.value
+			const [ent] = getResolvedEntries(entity, first_subfield, entries).filter((ent) => ent.parent === entry.id)
+			return ent?.value
 		} else return null
 	}
 
-	function get_title(repeater_item) {
-		const first_subfield = subfields.find((subfield) => ['text', 'markdown', 'link', 'number'].includes(subfield.type))
+	function get_title() {
+		const first_subfield = fields.find((subfield) => ['text', 'markdown', 'link', 'number'].includes(subfield.type))
 		if (first_subfield) {
 			// let { value } = subfields[0]
-			const content_entry = entries.find((r) => r.field === first_subfield.id && r.parent === repeater_item.id)
-			if (first_subfield.type === 'link') return content_entry?.value?.label
-			else if (first_subfield.type === 'markdown') return content_entry?.value?.markdown
-			else return content_entry?.value
+			const [ent] = getResolvedEntries(entity, first_subfield, entries).filter((ent) => ent.parent === entry.id)
+			if (first_subfield.type === 'link') return ent?.value?.label
+			else if (first_subfield.type === 'markdown') return ent?.value?.markdown
+			else return ent?.value
 		} else {
 			return singular_label
 		}
-	}
-
-	function check_condition(field, entry) {
-		if (!field.config?.condition) return true // has no condition
-
-		const { field: field_id, value, comparison } = field.config.condition
-		const field_to_compare = fields.find((f) => f.id === field_id)
-		if (!field_to_compare) {
-			// field has been deleted, reset condition
-			field.config.condition = null
-			return false
-		}
-
-		const { value: comparable_value } = entries.find((e) => e.field === field_id && e.parent === entry.parent)
-		if (is_regex(value)) {
-			const regex = new RegExp(value.slice(1, -1))
-			if (comparison === '=' && regex.test(comparable_value)) {
-				return true
-			} else if (comparison === '!=' && !regex.test(comparable_value)) {
-				return true
-			}
-		} else if (comparison === '=' && value === comparable_value) {
-			return true
-		} else if (comparison === '!=' && value !== comparable_value) {
-			return true
-		}
-		return false
 	}
 
 	let drag_handle_element = $state()
@@ -104,13 +85,13 @@
 		draggable({
 			element,
 			dragHandle: drag_handle_element,
-			getInitialData: () => ({ item: repeater_item })
+			getInitialData: () => ({})
 		})
 		dropTargetForElements({
 			element,
 			getData({ input, element }) {
 				return attachClosestEdge(
-					{ item: repeater_item },
+					{},
 					{
 						element,
 						input,
@@ -142,9 +123,9 @@
 		})
 	})
 	let singular_label = $derived($pluralize && $pluralize?.singular(field.label))
-	let item_image = $derived(get_image(repeater_item, field))
-	let item_icon = $derived(get_icon(repeater_item, field))
-	let item_title = $derived(get_title(repeater_item, field))
+	let item_image = $derived(get_image())
+	let item_icon = $derived(get_icon())
+	let item_title = $derived(get_title())
 </script>
 
 <div
@@ -172,45 +153,25 @@
 				<button bind:this={drag_handle_element}>
 					<Icon icon="material-symbols:drag-handle" />
 				</button>
-				<button title="Delete {singular_label} item" onclick={() => dispatch('remove', repeater_item)}>
+				<button title="Delete {singular_label} item" onclick={() => dispatch('remove')}>
 					<Icon icon="ion:trash" />
 				</button>
 			</div>
 		</div>
 		{#if is_visible}
 			<div class="field-values">
-				{#each subfields as subfield, subfield_index (repeater_item._key + subfield.key)}
-					{@const content_entry = get_content_entry(subfield)}
-					{@const is_visible = check_condition(subfield, content_entry)}
-					{#if !content_entry}
-						<span>Entry corrupted</span>
-					{:else if content_entry && is_visible}
-						{@const SvelteComponent = getFieldComponent(subfield)}
-						<div class="repeater-item-field" id="repeater-{field.key}-{index}-{subfield.key}">
-							<SvelteComponent
-								id={content_entry.id}
-								value={content_entry.value}
-								metadata={content_entry.metadata}
-								field={subfield}
-								{fields}
-								{entries}
-								level={level + 1}
-								show_label={true}
-								autofocus={autofocus && subfield_index === 0}
-								on:keydown
-								on:add
-								on:remove
-								on:move
-								oninput={(detail) => {
-									if (detail.id) {
-										oninput(detail)
-									} else {
-										oninput({ id: content_entry.id, data: detail })
-									}
-								}}
-							/>
-						</div>
-					{/if}
+				{#each subfields as subfield (subfield.key)}
+					<div class="repeater-item-field" id="repeater-{field.key}-{index}-{subfield.key}">
+						<EntryContent
+							{entity}
+							parent={entry}
+							field={subfield}
+							{fields}
+							{entries}
+							level={level + 1}
+							onchange={(values) => onchange({ [field.key]: { [index]: { value: null, subValues: values } } })}
+						/>
+					</div>
 				{/each}
 			</div>
 		{/if}

--- a/app/lib/builder/field-types/SelectField.svelte
+++ b/app/lib/builder/field-types/SelectField.svelte
@@ -4,8 +4,18 @@
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
 	import { SiteSymbolFields } from '$lib/pocketbase/collections'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: any) => void } = $props()
+	let {
+		field,
+		entry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+	} = $props()
 
 	const value = $derived(entry?.value)
 	// Access staged field config through collection mapping system
@@ -15,7 +25,7 @@
 
 <div class="SelectField">
 	{#if options.length > 0}
-		<UI.Select fullwidth={true} label={field.label} {options} {value} on:input={({ detail }) => onchange(detail)} />
+		<UI.Select fullwidth={true} label={field.label} {options} {value} on:input={({ detail }) => onchange({ [field.key]: { 0: { value: detail } } })} />
 	{:else}
 		<span>This field doesn't have any options</span>
 	{/if}

--- a/app/lib/builder/field-types/Slider.svelte
+++ b/app/lib/builder/field-types/Slider.svelte
@@ -2,9 +2,19 @@
 	import type { Entity } from '$lib/pocketbase/content'
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: string) => void } = $props()
-	
+	let {
+		field,
+		entry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+	} = $props()
+
 	const value = $derived(entry?.value ?? '')
 </script>
 
@@ -12,7 +22,7 @@
 	<p class="label">{field.label}</p>
 	<div class="container">
 		<p class="value">{value}</p>
-		<input oninput={({ target }) => onchange(target.value)} class="input" {value} type="range" />
+		<input oninput={({ target }) => onchange({ [field.key]: { 0: { value: target.value } } })} class="input" {value} type="range" />
 	</div>
 </div>
 

--- a/app/lib/builder/field-types/Switch.svelte
+++ b/app/lib/builder/field-types/Switch.svelte
@@ -3,12 +3,25 @@
 	import type { Entity } from '$lib/pocketbase/content'
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: boolean) => void } = $props()
+	let {
+		field,
+		entry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		fields: Field[]
+		entries: Entry[]
+		onchange: FieldValueHandler
+		level: number
+	} = $props()
 </script>
 
 <div>
-	<UI.Switch label={field.label} {field} value={entry?.value ?? false} oninput={(value) => onchange(value)} />
+	<UI.Switch label={field.label} {field} value={entry?.value ?? false} oninput={(value) => onchange({ [field.key]: { 0: { value } } })} />
 </div>
 
 <style lang="postcss">

--- a/app/lib/builder/field-types/Text.svelte
+++ b/app/lib/builder/field-types/Text.svelte
@@ -3,12 +3,22 @@
 	import type { Entity } from '$lib/pocketbase/content'
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: string) => void } = $props()
+	let {
+		field,
+		entry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+	} = $props()
 </script>
 
 <div>
-	<UI.TextInput {...field} value={entry?.value ?? ''} oninput={(text) => onchange(text)} />
+	<UI.TextInput {...field} value={entry?.value ?? ''} oninput={(text) => onchange({ [field.key]: { 0: { value: text } } })} />
 </div>
 
 <style lang="postcss">

--- a/app/lib/builder/field-types/TextField.svelte
+++ b/app/lib/builder/field-types/TextField.svelte
@@ -5,8 +5,18 @@
 	import type { Entity } from '$lib/pocketbase/content'
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: string) => void } = $props()
+	let {
+		field,
+		entry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+	} = $props()
 
 	let element
 	onMount(() => {
@@ -14,7 +24,7 @@
 	})
 </script>
 
-<TextInput label={field.label} value={entry?.value} grow={true} oninput={onchange} />
+<TextInput label={field.label} value={entry?.value} grow={true} oninput={(value) => onchange({ [field.key]: { 0: { value } } })} />
 
 <style lang="postcss">
 </style>

--- a/app/lib/builder/field-types/URL.svelte
+++ b/app/lib/builder/field-types/URL.svelte
@@ -3,12 +3,22 @@
 	import type { Entity } from '$lib/pocketbase/content'
 	import type { Field } from '$lib/common/models/Field'
 	import type { Entry } from '$lib/common/models/Entry'
+	import type { FieldValueHandler } from '../components/Fields/FieldsContent.svelte'
 
-	let { field, entry, onchange }: { entity: Omit<Entity, 'id'>; field: Omit<Field, 'id'>; entry?: Omit<Entry, 'id'>; onchange: (value: string) => void } = $props()
+	let {
+		field,
+		entry,
+		onchange
+	}: {
+		entity: Entity
+		field: Field
+		entry?: Entry
+		onchange: FieldValueHandler
+	} = $props()
 </script>
 
 <div>
-	<UI.TextInput {...field} value={entry?.value ?? ''} oninput={(text) => onchange(text)} type="url" />
+	<UI.TextInput {...field} value={entry?.value ?? ''} oninput={(text) => onchange({ [field.key]: { 0: { value: text } } })} type="url" />
 </div>
 
 <style lang="postcss">

--- a/app/lib/builder/utils.js
+++ b/app/lib/builder/utils.js
@@ -5,7 +5,7 @@ import { customAlphabet } from 'nanoid/non-secure'
 import { processors } from './component.js'
 
 const componentsCache = new Map()
-export async function processCode({ component, head = { code: '', data: {}}, buildStatic = true, format = 'esm', locale = 'en', hydrated = true }) {
+export async function processCode({ component, head = { code: '', data: {} }, buildStatic = true, format = 'esm', locale = 'en', hydrated = true }) {
 	let css = ''
 	if (component.css) {
 		css = await processCSS(component.css || '')
@@ -105,19 +105,11 @@ export function get_empty_value(field) {
 	else if (field.type === 'select') return ''
 	else if (field.type === 'switch') return true
 	else if (field.type === 'number') return 0
-
 	else if (field.type === 'page-field') return null
 	else if (field.type === 'site-field') return null
 	else {
 		console.warn('No placeholder set for field type', field.type)
 		return ''
-	}
-
-	function getGroupValue(field) {
-		return _chain(field.fields)
-			.keyBy('key')
-			.mapValues((field) => get_empty_value(field))
-			.value()
 	}
 }
 
@@ -178,7 +170,6 @@ export function compare_urls(url1, url2) {
 	// Compare the normalized URLs
 	return normalizedURL1 === normalizedURL2
 }
-
 
 export function debounce({ instant, delay }, wait = 200) {
 	let timeout

--- a/app/lib/builder/views/editor/Page.svelte
+++ b/app/lib/builder/views/editor/Page.svelte
@@ -9,11 +9,11 @@
 	import BlockToolbar from './Layout/BlockToolbar.svelte'
 	import LockedOverlay from './Layout/LockedOverlay.svelte'
 	import DropIndicator from './Layout/DropIndicator.svelte'
-	import { locale, locked_blocks, page_loaded, dragging_symbol } from '$lib/builder/stores/app/misc'
+	import { locale, locked_blocks, dragging_symbol } from '$lib/builder/stores/app/misc'
 	import { dropTargetForElements } from '$lib/builder/libraries/pragmatic-drag-and-drop/entry-point/element/adapter.js'
 	import { attachClosestEdge, extractClosestEdge } from '$lib/builder/libraries/pragmatic-drag-and-drop-hitbox/closest-edge.js'
 	import { beforeNavigate } from '$app/navigation'
-	import { Pages, Sites, SiteSymbols, PageSections, PageTypes, PageTypeSections, PageSectionEntries, PageTypeSectionEntries, SiteSymbolFields, manager } from '$lib/pocketbase/collections'
+	import { Pages, Sites, SiteSymbols, PageSections, PageTypes, PageSectionEntries, manager } from '$lib/pocketbase/collections'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping'
 
 	let { page }: { page: ObjectOf<typeof Pages> } = $props()
@@ -74,7 +74,8 @@
 					section: copied_section.id,
 					field: entry.field,
 					locale: entry.locale,
-					value: entry.value
+					value: entry.value,
+					index: entry.index
 				})
 			}
 			copied_sections.push(copied_section)

--- a/app/lib/builder/views/editor/PageType.svelte
+++ b/app/lib/builder/views/editor/PageType.svelte
@@ -14,9 +14,9 @@
 	import { locale } from '../../stores/app/misc.js'
 	import { dropTargetForElements } from '$lib/builder/libraries/pragmatic-drag-and-drop/entry-point/element/adapter.js'
 	import { attachClosestEdge, extractClosestEdge } from '$lib/builder/libraries/pragmatic-drag-and-drop-hitbox/closest-edge.js'
-	import { manager, PageTypes, PageTypeSectionEntries, PageTypeSections, PageTypeSymbols, Sites, SiteSymbolFields, SiteSymbols } from '$lib/pocketbase/collections'
-
+	import { manager, PageTypes, PageTypeSections, Sites } from '$lib/pocketbase/collections'
 	import { page } from '$app/state'
+	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.js'
 
 	const host = $derived(page.url.host)
 	const site = $derived(Sites.list({ filter: `host = "${host}"` })?.[0])
@@ -141,6 +141,7 @@
 		lock_block(hovered_section_id)
 		editing_section_tab = tab
 		editing_section = true
+		editing_section_target = hovered_section
 	}
 
 	let moving = $state(false) // workaround to prevent block toolbar from showing when moving blocks
@@ -407,6 +408,7 @@
 	})
 
 	let editing_section = $state(false)
+	let editing_section_target = $state<ObjectOf<typeof PageTypeSections>>()
 </script>
 
 <Dialog.Root
@@ -419,13 +421,12 @@
 >
 	<Dialog.Content class="z-[999] max-w-[1600px] h-full max-h-[100vh] flex flex-col p-4">
 		<SectionEditor
-			component={hovered_section}
+			component={editing_section_target}
 			tab={editing_section_tab}
 			header={{
 				button: {
 					label: 'Save',
-					onclick: (updated_data) => {
-						Object.assign(hovered_section, updated_data)
+					onclick: () => {
 						hovering_toolbar = false
 						editing_section = false
 					}

--- a/app/lib/builder/views/editor/Toolbar.svelte
+++ b/app/lib/builder/views/editor/Toolbar.svelte
@@ -24,15 +24,14 @@
 	import type { Snippet } from 'svelte'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping'
 
-	let { children, currentPage, site }: { children: Snippet; currentPage?: ObjectOf<typeof Pages>; site?: ObjectOf<typeof Sites> } = $props()
+	let { children, site }: { children: Snippet; site?: ObjectOf<typeof Sites> } = $props()
 
-	// Fallback to hostname lookup if no site prop provided (for backward compatibility)
 	const host = $derived(pageState.url.host)
 	const fallback_site = $derived(Sites.list({ filter: `host = "${host}"` })?.[0])
 	const resolved_site = $derived(site || fallback_site)
 	const page_slug = $derived(pageState.params.page || '')
 	const page_type_id = $derived(pageState.params.page_type)
-	const page = $derived(currentPage ?? (resolved_site && page_slug ? Pages.list({ filter: `site = "${resolved_site.id}" && slug = "${page_slug}"` })?.[0] : undefined))
+	const page = $derived(resolved_site && page_slug ? Pages.list({ filter: `site = "${resolved_site.id}" && slug = "${page_slug}"` })?.[0] : undefined)
 	const page_type = $derived(page_type_id && PageTypes.one(page_type_id))
 	const page_page_type = $derived(page && PageTypes.one(page.page_type))
 

--- a/app/lib/builder/views/modal/BlockEditor.svelte
+++ b/app/lib/builder/views/modal/BlockEditor.svelte
@@ -9,7 +9,7 @@
 	import { PaneGroup, Pane, PaneResizer } from 'paneforge'
 	import FullCodeEditor from './SectionEditor/FullCodeEditor.svelte'
 	import ComponentPreview, { has_error } from '$lib/builder/components/ComponentPreview.svelte'
-	import Fields from '$lib/builder/components/Fields/FieldsContent.svelte'
+	import Fields, { setFieldEntries } from '$lib/builder/components/Fields/FieldsContent.svelte'
 	import { locale } from '$lib/builder/stores/app/misc.js'
 	import hotkey_events from '$lib/builder/stores/app/hotkey_events.js'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping'
@@ -132,33 +132,19 @@
 						})
 					}}
 					oninput={(values) => {
-						for (const [key, value] of Object.entries(values)) {
-							const field = fields.find((field) => field.key === key)
-							if (!field) {
-								continue
-							}
-
-							const entry = entries.find((entry) => entry.field === field?.id)
-							if (entry) {
-								SiteSymbolEntries.update(entry.id, { value })
-							} else {
-								SiteSymbolEntries.create({ field: field.id, locale: 'en', value })
-							}
-						}
+						setFieldEntries({
+							fields,
+							entries,
+							updateEntry: SiteSymbolEntries.update,
+							createEntry: SiteSymbolEntries.create,
+							values
+						})
 					}}
 					onchange={({ id, data }) => {
 						SiteSymbolFields.update(id, data)
 					}}
 					ondelete={(field_id) => {
 						SiteSymbolFields.delete(field_id)
-					}}
-					onadd={({ parent, index, subfields }) => {
-						// Create an entry for the repeater item
-						SiteSymbolEntries.create({
-							field: parent,
-							locale: 'en',
-							value: {}
-						})
 					}}
 				/>
 			{/if}

--- a/app/lib/builder/views/modal/PageEditor.svelte
+++ b/app/lib/builder/views/modal/PageEditor.svelte
@@ -2,7 +2,7 @@
 	import Icon from '@iconify/svelte'
 	import * as Dialog from '$lib/components/ui/dialog'
 	import { PaneGroup, Pane, PaneResizer } from 'paneforge'
-	import Fields from '$lib/builder/components/Fields/FieldsContent.svelte'
+	import Fields, { setFieldEntries } from '$lib/builder/components/Fields/FieldsContent.svelte'
 	import * as _ from 'lodash-es'
 	import CodeEditor from '$lib/builder/components/CodeEditor/CodeMirror.svelte'
 	import { page } from '$app/state'
@@ -76,35 +76,19 @@
 						})
 					}}
 					oninput={(values) => {
-						console.log('oninput')
-						for (const [key, value] of Object.entries(values)) {
-							const field = fields.find((field) => field.key === key)
-							if (!field) {
-								continue
-							}
-
-							const entry = entries.find((entry) => entry.field === field?.id)
-							if (entry) {
-								console.log({ entry, value })
-								PageTypeEntries.update(entry.id, { value })
-							} else {
-								PageTypeEntries.create({ field: field.id, locale: 'en', value })
-							}
-						}
+						setFieldEntries({
+							fields,
+							entries,
+							updateEntry: PageTypeEntries.update,
+							createEntry: PageTypeEntries.create,
+							values
+						})
 					}}
 					onchange={({ id, data }) => {
 						PageTypeFields.update(id, data)
 					}}
 					ondelete={(field_id) => {
 						PageTypeFields.delete(field_id)
-					}}
-					onadd={({ parent, index, subfields }) => {
-						// Create an entry for the repeater item
-						PageTypeEntries.create({
-							field: parent,
-							locale: 'en',
-							value: {}
-						})
 					}}
 				/>
 			</Pane>

--- a/app/lib/builder/views/modal/SiteEditor/SiteEditor.svelte
+++ b/app/lib/builder/views/modal/SiteEditor/SiteEditor.svelte
@@ -1,8 +1,8 @@
-<script>
+<script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog'
 	import Icon from '@iconify/svelte'
 	import { PaneGroup, Pane, PaneResizer } from 'paneforge'
-	import Fields from '$lib/builder/components/Fields/FieldsContent.svelte'
+	import Fields, { setFieldEntries } from '$lib/builder/components/Fields/FieldsContent.svelte'
 	import * as _ from 'lodash-es'
 	import CodeEditor from '$lib/builder/components/CodeEditor/CodeMirror.svelte'
 	import { setContext } from 'svelte'
@@ -74,29 +74,28 @@
 						{fields}
 						{entries}
 						create_field={async (parentId) => {
+							// Get the highest index for fields at this level
+							const siblingFields = fields?.filter((f) => f.parent === parentId) || []
+							const nextIndex = Math.max(...siblingFields.map((f) => f.index || 0), -1) + 1
+
 							return SiteFields.create({
 								type: 'text',
 								key: '',
 								label: '',
 								config: null,
 								site: site.id,
-								parent: parentId || ''
+								parent: parentId || '',
+								index: nextIndex
 							})
 						}}
 						oninput={(values) => {
-							for (const [key, value] of Object.entries(values)) {
-								const field = fields?.find((field) => field.key === key)
-								if (!field) {
-									continue
-								}
-
-								const entry = entries?.find((entry) => entry.field === field?.id)
-								if (entry) {
-									SiteEntries.update(entry.id, { value })
-								} else {
-									SiteEntries.create({ field: field.id, locale: 'en', value })
-								}
-							}
+							setFieldEntries({
+								fields,
+								entries,
+								updateEntry: SiteEntries.update,
+								createEntry: SiteEntries.create,
+								values
+							})
 						}}
 						onchange={({ id, data }) => {
 							SiteFields.update(id, data)
@@ -104,14 +103,6 @@
 						ondelete={(field_id) => {
 							// PocketBase cascade deletion will automatically clean up all associated entries
 							SiteFields.delete(field_id)
-						}}
-						onadd={({ parent, index, subfields }) => {
-							// Create an entry for the repeater item
-							SiteEntries.create({
-								field: parent,
-								locale: 'en',
-								value: {}
-							})
 						}}
 					/>
 				</Pane>

--- a/app/lib/common/models/Entry.ts
+++ b/app/lib/common/models/Entry.ts
@@ -7,7 +7,7 @@ export const Entry = z.object({
 	value: z.any(),
 	field: z.string().nonempty().optional(),
 	parent: z.string().optional().nullable(),
-	index: z.number().optional().nullable()
+	index: z.number().int().nonnegative()
 })
 
 export type Entry = z.infer<typeof Entry>

--- a/app/lib/common/models/FieldBase.ts
+++ b/app/lib/common/models/FieldBase.ts
@@ -7,7 +7,7 @@ export const FieldBase = z.object({
 	type: z.string().nonempty(),
 	config: z.any().nullable(),
 	parent: z.string().optional(),
-	index: z.number().optional()
+	index: z.number().int().nonnegative()
 })
 
 export type FieldBase = z.infer<typeof FieldBase>

--- a/app/lib/common/models/fields/RepeaterField.ts
+++ b/app/lib/common/models/fields/RepeaterField.ts
@@ -3,7 +3,6 @@ import { FieldBase } from '../FieldBase'
 
 export const RepeaterField = FieldBase.extend({
 	type: z.literal('repeater')
-	// TODO: Sub-fields
 })
 
 export type RepeaterField = z.infer<typeof RepeaterField>

--- a/app/lib/pocketbase/collections.ts
+++ b/app/lib/pocketbase/collections.ts
@@ -47,13 +47,7 @@ export const LibrarySymbols = createCollectionMapping('library_symbols', Library
 			return LibrarySymbolFields.from(this.collection.instance).list({ filter: `symbol = "${this.id}"` })
 		},
 		entries() {
-			const fields = LibrarySymbolFields.from(this.collection.instance).list({ filter: `symbol = "${this.id}"` })
-			if (!fields) return undefined
-
-			const entryLists = fields.map((field) => field.entries())
-			if (entryLists.some((list) => list === undefined)) return undefined
-
-			return entryLists.filter((list) => list !== undefined).flat()
+			return LibrarySymbolEntries.from(this.collection.instance).list({ filter: `field.symbol = "${this.id}"` })
 		}
 	}
 })
@@ -87,13 +81,7 @@ export const Sites = createCollectionMapping('sites', Site, manager, {
 			return SiteFields.from(this.collection.instance).list({ filter: `site = "${this.id}"` })
 		},
 		entries() {
-			const fields = SiteFields.from(this.collection.instance).list({ filter: `site = "${this.id}"` })
-			if (!fields) return undefined
-
-			const entryLists = fields.map((field) => field.entries())
-			if (entryLists.some((list) => list === undefined)) return undefined
-
-			return entryLists.filter((list) => list !== undefined).flat()
+			return SiteEntries.from(this.collection.instance).list({ filter: `field.site = "${this.id}"` })
 		},
 		page_types() {
 			return PageTypes.from(this.collection.instance).list({ filter: `site = "${this.id}"` })
@@ -125,13 +113,7 @@ export const SiteSymbols = createCollectionMapping('site_symbols', SiteSymbol, m
 			return SiteSymbolFields.from(this.collection.instance).list({ filter: `symbol = "${this.id}"` })
 		},
 		entries() {
-			const fields = SiteSymbolFields.from(this.collection.instance).list({ filter: `symbol = "${this.id}"` })
-			if (!fields) return undefined
-
-			const entryLists = fields.map((field) => field.entries())
-			if (entryLists.some((list) => list === undefined)) return undefined
-
-			return entryLists.filter((list) => list !== undefined).flat()
+			return SiteSymbolEntries.from(this.collection.instance).list({ filter: `field.symbol = "${this.id}"` })
 		}
 	}
 })
@@ -160,13 +142,7 @@ export const PageTypes = createCollectionMapping('page_types', PageType, manager
 			return PageTypeFields.from(this.collection.instance).list({ filter: `page_type = "${this.id}"` })
 		},
 		entries() {
-			const fields = PageTypeFields.from(this.collection.instance).list({ filter: `page_type = "${this.id}"` })
-			if (!fields) return undefined
-
-			const entryLists = fields.map((field) => field.entries())
-			if (entryLists.some((list) => list === undefined)) return undefined
-
-			return entryLists.filter((list) => list !== undefined).flat()
+			return PageTypeEntries.from(this.collection.instance).list({ filter: `field.page_type = "${this.id}"` })
 		}
 	}
 })

--- a/app/lib/pocketbase/content.ts
+++ b/app/lib/pocketbase/content.ts
@@ -2,7 +2,7 @@ import { find as _find, chain as _chain, flattenDeep as _flattenDeep } from 'lod
 import * as _ from 'lodash-es'
 import type { Entry } from '$lib/common/models/Entry.js'
 import type { locales } from '../common'
-import { SiteFields, Sites, Pages, SiteSymbolFields, PageTypeFields, PageTypes } from './collections'
+import { SiteFields, Sites, Pages, SiteSymbolFields, PageTypeFields, PageTypes, SiteSymbols } from './collections'
 import { LibrarySymbolEntry } from '../common/models/LibrarySymbolEntry'
 import type { models } from '$lib/common/models'
 import type { z } from 'zod'
@@ -13,6 +13,7 @@ import { SiteSymbolEntry } from '../common/models/SiteSymbolEntry'
 import { SiteEntry } from '../common/models/SiteEntry'
 import { PageTypeEntry } from '$lib/common/models/PageTypeEntry'
 import { PageEntry } from '$lib/common/models/PageEntry'
+import { get_empty_value } from '$lib/builder/utils'
 
 /**
  * Entry models by name of the owning collection.
@@ -31,64 +32,44 @@ export type EntryOf<Collection extends keyof typeof ENTRY_MODELS> = z.TypeOf<(ty
 export type EntityOf<Collection extends keyof typeof ENTRY_MODELS> = z.TypeOf<(typeof models)[Collection]>
 export type Entity = EntityOf<keyof typeof ENTRY_MODELS>
 
-export const getContent = <Collection extends keyof typeof ENTRY_MODELS>(entity: EntityOf<Collection>, fields: Field[], entries: EntryOf<Collection>[]) => {
-	const content: { [K in (typeof locales)[number]]?: Record<string, unknown[]> } = {}
-	fields = fields
+export const getContent = <Collection extends keyof typeof ENTRY_MODELS>(entity: EntityOf<Collection>, fields: Field[], entries: EntryOf<Collection>[], parentField?: Field, parentEntry?: Entry) => {
+	const content: { [K in (typeof locales)[number]]?: Record<string, unknown> } = {}
+	const filteredFields = fields
 		.filter((field) =>
 			'symbol' in entity
 				? 'symbol' in field && field.symbol === entity.symbol
 				: (!('symbol' in field) || field.symbol === entity.id) && (!('site' in field) || field.site === entity.id) && (!('page_type' in field) || field.page_type === entity.id)
 		)
+		.filter((field) => (parentField ? field.parent === parentField.id : !field.parent))
 		// Deduplicate
 		.filter((field1, index, array) => array.findIndex((field2) => field2.id === field1.id) === index)
-	for (const field of fields) {
-		const fieldEntries = getResolvedEntries(entity, field, entries)
-		
+	for (const field of filteredFields) {
+		const fieldEntries = getResolvedEntries(entity, field, entries).filter((entry) => (parentEntry ? entry.parent === parentEntry.id : !entry.parent))
+
 		// Handle group fields specially - collect subfield entries into an object
 		if (field.type === 'group' && field.key) {
-			if (!content.en) content.en = {}
-			
-			// Find all subfields for this group
-			const subfields = fields.filter(f => f.parent === field.id)
-			const groupObject: Record<string, unknown> = {}
-			
-			// Collect each subfield's value
-			for (const subfield of subfields) {
-				const subfieldEntries = getDirectEntries(entity, subfield, entries)
-				if (subfieldEntries.length > 0) {
-					// Use the last entry if there are multiple (same as single fields)
-					const subfieldEntry = subfieldEntries[subfieldEntries.length - 1]
-					groupObject[subfield.key] = subfieldEntry.value
-				} else {
-					// Default empty value for missing subfields
-					groupObject[subfield.key] = ''
-				}
+			const [entry] = fieldEntries
+			if (!content[entry.locale]) content[entry.locale] = {}
+			content[entry.locale]![field.key] = getContent(entity, fields, entries, field, entry)[entry.locale]
+		}
+		// Handle repeater fields specially - collect array of subfield entries into an object
+		else if (field.type === 'repeater' && field.key) {
+			for (const entry of fieldEntries) {
+				if (!content[entry.locale]) content[entry.locale] = {}
+				if (!content[entry.locale]![field.key]) content[entry.locale]![field.key] = []
+				;(content[entry.locale]![field.key] as unknown[]).push(getContent(entity, fields, entries, field, entry)[entry.locale])
 			}
-			
-			content.en![field.key] = groupObject
 		}
 		// If field has a key but no entries, fill with empty value
 		else if (field.key && fieldEntries.length === 0) {
 			if (!content.en) content.en = {}
-			// For repeater fields, use empty array; for single fields, use empty string/appropriate default
-			if (field.type === 'repeater') {
-				content.en![field.key] = []
-			} else {
-				content.en![field.key] = ''
-			}
-		} else {
-			for (const entry of fieldEntries) {
-				if (!content[entry.locale]) content[entry.locale] = {}
-				
-				// For repeater fields, collect values in array; for single fields, use direct value
-				if (field.type === 'repeater') {
-					if (!content[entry.locale]![field.key]) content[entry.locale]![field.key] = []
-					content[entry.locale]![field.key].push(entry.value)
-				} else {
-					// For single-value fields, just use the value directly (last one wins if multiple)
-					content[entry.locale]![field.key] = entry.value
-				}
-			}
+			content.en![field.key] = get_empty_value(field)
+		}
+		// For single-value fields, collect just get the first value
+		else {
+			const [entry] = fieldEntries
+			if (!content[entry.locale]) content[entry.locale] = {}
+			content[entry.locale]![field.key] = entry.value
 		}
 	}
 	return content
@@ -96,7 +77,7 @@ export const getContent = <Collection extends keyof typeof ENTRY_MODELS>(entity:
 
 export const getDirectEntries = <Collection extends keyof typeof ENTRY_MODELS>(entity: EntityOf<Collection>, field: Field, entries: EntryOf<Collection>[]): EntryOf<Collection>[] => {
 	if (!entries) return []
-	return entries.filter((entry) => entry.field === field.id && (!('section' in entry) || entry.section === entity.id))
+	return entries.filter((entry) => entry.field === field.id && (!('section' in entry) || entry.section === entity.id)).sort((a, b) => a.index - b.index)
 }
 
 export const getResolvedEntries = <Collection extends keyof typeof ENTRY_MODELS>(entity: EntityOf<Collection>, field: Field, entries: EntryOf<Collection>[]): Entry[] => {
@@ -107,13 +88,13 @@ export const getResolvedEntries = <Collection extends keyof typeof ENTRY_MODELS>
 			console.log('page-field: no config.field')
 			return []
 		}
-		
+
 		const pageField = PageTypeFields.one(field.config.field)
 		if (!pageField) {
 			console.log('page-field: pageField not found for', field.config.field)
 			return []
 		}
-		
+
 		// Get the page entity and its entries
 		let pageEntity, pageEntries
 		if ('page' in entity) {
@@ -125,75 +106,76 @@ export const getResolvedEntries = <Collection extends keyof typeof ENTRY_MODELS>
 			pageEntity = entity
 			pageEntries = entries
 		}
-		
+
 		// Get entries for the referenced field from the page
 		const directEntries = getDirectEntries(pageEntity, pageField, pageEntries)
 		return directEntries
 	} else if (field.type === 'site-field') {
 		// For site-field, get the referenced field value directly from the site
 		if (!field.config?.field) return []
-		
+
 		const siteField = SiteFields.one(field.config.field)
 		if (!siteField) return []
-		
+
 		// Get the site entity and its entries
 		const site = Sites.one(siteField.site)
 		if (!site) return []
-		
+
 		const siteEntries = site.entries() || []
-		
+
 		// Get entries for the referenced field from the site
 		const directEntries = getDirectEntries(site, siteField, siteEntries)
 		return directEntries
 	} else if (field.type === 'page') {
-		return fieldEntries.map((entry) => {
-			const page = Pages.one(entry.value)
-			if (!page) return null
-			
-			// Get all entries from all fields in the page
-			const pageEntries = page.entries() || []
-			// Get fields from the page's page type
-			const pageType = PageTypes.one(page.page_type)
-			if (!pageType) return null
-			
-			// Build the page content object manually
-			const pageFields = pageType.fields() || []
-			const pageContentObject = {}
-			
-			for (const pageField of pageFields) {
-				const fieldEntries = pageEntries.filter(e => e.field === pageField.id)
-				if (fieldEntries.length > 0) {
-					// Use the last entry if there are multiple (same as getContent logic)
-					const fieldEntry = fieldEntries[fieldEntries.length - 1]
-					pageContentObject[pageField.key] = fieldEntry.value
+		return fieldEntries
+			.map((entry) => {
+				const page = Pages.one(entry.value)
+				if (!page) return null
+
+				// Get all entries from all fields in the page
+				const pageEntries = page.entries() || []
+				// Get fields from the page's page type
+				const pageType = PageTypes.one(page.page_type)
+				if (!pageType) return null
+
+				// Build the page content object manually
+				const pageFields = pageType.fields() || []
+				const pageContentObject = {}
+
+				for (const pageField of pageFields) {
+					const fieldEntries = pageEntries.filter((e) => e.field === pageField.id)
+					if (fieldEntries.length > 0) {
+						// Use the last entry if there are multiple (same as getContent logic)
+						const fieldEntry = fieldEntries[fieldEntries.length - 1]
+						pageContentObject[pageField.key] = fieldEntry.value
+					}
 				}
-			}
-			
-			// Create the page field value with content and metadata
-			const pageValue = {
-				...pageContentObject,
-				_meta: {
-					created_at: page.created,
-					name: page.name,
-					slug: page.slug,
-					url: `/${page.slug}`
+
+				// Create the page field value with content and metadata
+				const pageValue = {
+					...pageContentObject,
+					_meta: {
+						created_at: page.created,
+						name: page.name,
+						slug: page.slug,
+						url: `/${page.slug}`
+					}
 				}
-			}
-			
-			// Return an entry with the structured page value
-			return {
-				...entry,
-				value: pageValue
-			}
-		}).filter(Boolean)
+
+				// Return an entry with the structured page value
+				return {
+					...entry,
+					value: pageValue
+				}
+			})
+			.filter(Boolean)
 	} else if (field.type === 'page-list') {
 		return fieldEntries.flatMap((entry) =>
 			entry.value.flatMap((page_id: string) => {
 				const page = Pages.one(page_id)
 				if (!page) return []
-				const symbols = page
-					.sections()
-					.map((section) => section.symbol())
+				const symbols = (page.sections() ?? [])
+					.map((section) => SiteSymbols.one(section.symbol))
 					.filter(isNotUndefined)
 					.filter(deduplicate)
 				const fields = symbols.flatMap((symbol) => symbol.fields())

--- a/app/routes/site/+layout.svelte
+++ b/app/routes/site/+layout.svelte
@@ -18,8 +18,6 @@
 	const host = $derived(page.url.host)
 	const sites = $derived(Sites.list({ filter: `host = "${host}"` }))
 	const site = $derived(sites?.[0])
-	const page_slug = $derived(page.params.page || '')
-	const current_page = $derived(site && Pages.list({ filter: `site = "${site.id}" && slug = "${page_slug}"` })?.[0])
 
 	let creating_site = $state(false)
 	$effect(() => {
@@ -35,8 +33,8 @@
 			creating_site = false
 		}}
 	/>
-{:else if site && current_page}
-	<Primo {site} currentPage={current_page}>
+{:else if site}
+	<Primo {site}>
 		{@render children?.()}
 	</Primo>
 {:else}

--- a/app/routes/sites/[site_id]/+layout.svelte
+++ b/app/routes/sites/[site_id]/+layout.svelte
@@ -16,16 +16,10 @@
 
 	const site_id = $derived(page.params.site_id)
 	const site = $derived(Sites.one(site_id))
-	const page_slug = $derived(page.params.page || '')
-	const current_page = $derived(() => {
-		if (!site) return undefined
-		if (!page_slug) return site.homepage()
-		return Pages.list({ filter: `site = "${site.id}" && slug = "${page_slug}"` })?.[0]
-	})
 </script>
 
-{#if site && current_page}
-	<Primo {site} currentPage={current_page}>
+{#if site}
+	<Primo {site}>
 		{@render children?.()}
 	</Primo>
 {:else}

--- a/pb_migrations/1753878221_updated_site_entries.js
+++ b/pb_migrations/1753878221_updated_site_entries.js
@@ -1,0 +1,63 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_298548709')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: []
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			4,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: true,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_298548709')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: ['CREATE UNIQUE INDEX `idx_1ygdlrWlu8` ON `site_entries` (\n  `field`,\n  `locale`\n)']
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			4,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: false,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	}
+)

--- a/pb_migrations/1753878233_updated_site_symbol_entries.js
+++ b/pb_migrations/1753878233_updated_site_symbol_entries.js
@@ -1,0 +1,63 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_1163071009')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: []
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			4,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: true,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_1163071009')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: ['CREATE INDEX `idx_XKqGoolCRa` ON `site_symbol_entries` (\n  `locale`,\n  `field`\n)']
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			4,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: false,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	}
+)

--- a/pb_migrations/1753878247_updated_page_type_section_entries.js
+++ b/pb_migrations/1753878247_updated_page_type_section_entries.js
@@ -1,0 +1,63 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_3303549340')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: []
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			5,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: true,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_3303549340')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: ['CREATE UNIQUE INDEX `idx_iN1Hji8J4T` ON `page_type_section_entries` (\n  `section`,\n  `locale`,\n  `field`\n)']
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			5,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: false,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	}
+)

--- a/pb_migrations/1753878252_updated_page_type_entries.js
+++ b/pb_migrations/1753878252_updated_page_type_entries.js
@@ -1,0 +1,70 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_638150767')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: []
+			},
+			collection
+		)
+
+		// add field
+		collection.fields.addAt(
+			3,
+			new Field({
+				cascadeDelete: false,
+				collectionId: 'pbc_638150767',
+				hidden: false,
+				id: 'relation1032740943',
+				maxSelect: 1,
+				minSelect: 0,
+				name: 'parent',
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'relation'
+			})
+		)
+
+		// add field
+		collection.fields.addAt(
+			4,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: true,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_638150767')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: ['CREATE UNIQUE INDEX `idx_pgGoOJxC2q` ON `page_type_entries` (\n  `field`,\n  `locale`\n)']
+			},
+			collection
+		)
+
+		// remove field
+		collection.fields.removeById('relation1032740943')
+
+		// remove field
+		collection.fields.removeById('number2155046657')
+
+		return app.save(collection)
+	}
+)

--- a/pb_migrations/1753878375_updated_page_section_entries.js
+++ b/pb_migrations/1753878375_updated_page_section_entries.js
@@ -1,0 +1,63 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_2653269516')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: []
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			5,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: true,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_2653269516')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: ['CREATE UNIQUE INDEX `idx_AFuS36r6qS` ON `page_section_entries` (\n  `locale`,\n  `section`,\n  `field`\n)']
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			5,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: false,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	}
+)

--- a/pb_migrations/1753878394_updated_page_entries.js
+++ b/pb_migrations/1753878394_updated_page_entries.js
@@ -1,0 +1,50 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_2147490902')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: []
+			},
+			collection
+		)
+
+		// add field
+		collection.fields.addAt(
+			4,
+			new Field({
+				cascadeDelete: false,
+				collectionId: 'pbc_2147490902',
+				hidden: false,
+				id: 'relation1032740943',
+				maxSelect: 1,
+				minSelect: 0,
+				name: 'parent',
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'relation'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_2147490902')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: ['CREATE UNIQUE INDEX `idx_VZ8zvbu4HP` ON `page_entries` (\n  `field`,\n  `locale`,\n  `page`\n)']
+			},
+			collection
+		)
+
+		// remove field
+		collection.fields.removeById('relation1032740943')
+
+		return app.save(collection)
+	}
+)

--- a/pb_migrations/1753878402_updated_library_symbol_entries.js
+++ b/pb_migrations/1753878402_updated_library_symbol_entries.js
@@ -1,0 +1,63 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_2026017886')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: []
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			4,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: true,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_2026017886')
+
+		// update collection data
+		unmarshal(
+			{
+				indexes: ['CREATE UNIQUE INDEX `idx_ZufbNLMdPV` ON `library_symbol_entries` (\n  `locale`,\n  `field`\n)']
+			},
+			collection
+		)
+
+		// update field
+		collection.fields.addAt(
+			4,
+			new Field({
+				hidden: false,
+				id: 'number2155046657',
+				max: null,
+				min: 0,
+				name: 'index',
+				onlyInt: false,
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'number'
+			})
+		)
+
+		return app.save(collection)
+	}
+)

--- a/pb_migrations/1753878470_updated_page_type_fields.js
+++ b/pb_migrations/1753878470_updated_page_type_fields.js
@@ -1,0 +1,34 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_1424058439')
+
+		// add field
+		collection.fields.addAt(
+			5,
+			new Field({
+				cascadeDelete: false,
+				collectionId: 'pbc_1424058439',
+				hidden: false,
+				id: 'relation1032740943',
+				maxSelect: 1,
+				minSelect: 0,
+				name: 'parent',
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'relation'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_1424058439')
+
+		// remove field
+		collection.fields.removeById('relation1032740943')
+
+		return app.save(collection)
+	}
+)

--- a/pb_migrations/1753878534_updated_library_symbol_fields.js
+++ b/pb_migrations/1753878534_updated_library_symbol_fields.js
@@ -1,0 +1,34 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_1105483583')
+
+		// add field
+		collection.fields.addAt(
+			5,
+			new Field({
+				cascadeDelete: false,
+				collectionId: 'pbc_1105483583',
+				hidden: false,
+				id: 'relation1032740943',
+				maxSelect: 1,
+				minSelect: 0,
+				name: 'parent',
+				presentable: false,
+				required: false,
+				system: false,
+				type: 'relation'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_1105483583')
+
+		// remove field
+		collection.fields.removeById('relation1032740943')
+
+		return app.save(collection)
+	}
+)


### PR DESCRIPTION
## Changes
- Centralize field rendering into EntryContent component
- Allow field actions (eg. duplicate) from nested fields
- Add helper function setFieldEntries with ability to set nested entries
- Add type for FieldValueHandler that allows setting values for nested fields and nested entries
- Fix site and page reference fields
- Ensure that all field and entry collections have parent field and mandatory index field with non-negative integer value
- Fix error related to passed "currentPage" prop by removing the prop
- Fix duplication of staged collection records by linking collections directly to each other without looping
- Fix getContent

## Test Plan for Reviewer
- [ ] Create repeater field and use it
- [ ] Create group field and use it
- [ ] Create site field reference field and use it
- [ ] Create page field reference field and use it