### PR TITLE
Ensure that current session is valid

### DIFF
--- a/app/lib/pocketbase/PocketBase.ts
+++ b/app/lib/pocketbase/PocketBase.ts
@@ -2,9 +2,6 @@ import type { User } from '$lib/common/models/User'
 import PocketBase from 'pocketbase'
 
 export const self = new PocketBase(import.meta.env.DEV ? 'http://127.0.0.1:8090' : '/')
-// Disable auto-cancellation for debugging
-self.autoCancellation(false)
-
 export const marketplace = new PocketBase('https://marketplace.palacms.org')
 
 export const user = () => {

--- a/app/lib/pocketbase/PocketBase.ts
+++ b/app/lib/pocketbase/PocketBase.ts
@@ -7,3 +7,18 @@ export const marketplace = new PocketBase('https://marketplace.palacms.org')
 export const user = () => {
 	return self.authStore.record as unknown as User | undefined
 }
+
+export const checkSession = async () => {
+	if (self.authStore.isValid) {
+		return self
+			.collection('users')
+			.authRefresh()
+			.then(() => true)
+			.catch(() => {
+				self.authStore.clear()
+				return false
+			})
+	} else {
+		return false
+	}
+}

--- a/app/routes/+page.svelte
+++ b/app/routes/+page.svelte
@@ -1,10 +1,10 @@
 <script>
 	import { goto } from '$app/navigation'
-	import { self } from '$lib/pocketbase/PocketBase'
+	import { checkSession } from '$lib/pocketbase/PocketBase'
 	import { onMount } from 'svelte'
 
 	onMount(async () => {
-		if (self.authStore.isValid) {
+		if (await checkSession()) {
 			await goto('/admin/site', { replaceState: true })
 		} else {
 			await goto('/admin/auth', { replaceState: true })

--- a/app/routes/auth/+layout.svelte
+++ b/app/routes/auth/+layout.svelte
@@ -1,10 +1,10 @@
 <script>
 	import { goto } from '$app/navigation'
-	import { self } from '$lib/pocketbase/PocketBase'
+	import { checkSession } from '$lib/pocketbase/PocketBase'
 	import { onMount } from 'svelte'
 
 	onMount(async () => {
-		if (self.authStore.isValid) {
+		if (await checkSession()) {
 			await goto('/admin/site')
 		}
 	})

--- a/app/routes/dashboard/+layout.svelte
+++ b/app/routes/dashboard/+layout.svelte
@@ -3,12 +3,12 @@
 	import AppSidebar from '$lib/components/app-sidebar.svelte'
 	import { Globe, LayoutTemplate, Store, Library, Cuboid } from 'lucide-svelte'
 	import { page } from '$app/state'
-	import { self } from '$lib/pocketbase/PocketBase'
+	import { checkSession } from '$lib/pocketbase/PocketBase'
 	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
 
 	onMount(async () => {
-		if (!self.authStore.isValid) {
+		if (!(await checkSession())) {
 			await goto('/admin/auth')
 		}
 	})

--- a/app/routes/site/+layout.svelte
+++ b/app/routes/site/+layout.svelte
@@ -1,6 +1,6 @@
 <script>
 	import Primo from '$lib/builder/Primo.svelte'
-	import { self, user } from '$lib/pocketbase/PocketBase'
+	import { checkSession, self } from '$lib/pocketbase/PocketBase'
 	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
 	import { page } from '$app/state'
@@ -8,7 +8,7 @@
 	import CreateSite from '$lib/components/CreateSite.svelte'
 
 	onMount(async () => {
-		if (!self.authStore.isValid) {
+		if (!(await checkSession())) {
 			await goto('/admin/auth')
 		}
 	})

--- a/app/routes/sites/[site_id]/+layout.svelte
+++ b/app/routes/sites/[site_id]/+layout.svelte
@@ -1,13 +1,13 @@
 <script>
 	import Primo from '$lib/builder/Primo.svelte'
-	import { self } from '$lib/pocketbase/PocketBase'
+	import { checkSession } from '$lib/pocketbase/PocketBase'
 	import { onMount } from 'svelte'
 	import { goto } from '$app/navigation'
 	import { page } from '$app/state'
 	import { Sites, Pages } from '$lib/pocketbase/collections'
 
 	onMount(async () => {
-		if (!self.authStore.isValid) {
+		if (!(await checkSession())) {
 			await goto('/admin/auth')
 		}
 	})


### PR DESCRIPTION
This fixes for example a common scenario in development where cookies need to be cleared because old session (with old database) does not get invalidated. This might also fix other authentication related issues that can occur in production.

## Changes

- Re-enable auto-cancellation for PocketBase client
- Ensure that current session is valid by calling authRefresh