### PR TITLE
Fix CSS on published pages and previews

### DIFF
--- a/app/lib/compiler/workers/rollup.worker.js
+++ b/app/lib/compiler/workers/rollup.worker.js
@@ -82,7 +82,7 @@ async function rollup_worker({ component, head, hydrated, buildStatic = true, cs
 	if (buildStatic) {
 		const bundle = await compile({
 			generate: 'server',
-			css
+			css: 'injected'
 		})
 
 		const output = (await bundle.generate({ format })).output[0].code


### PR DESCRIPTION
CSS was not being included for published pages and previews. This change fixes it by including CSS in components' SSR bundles, which are used for static page rendering. This shouldn't change the fact that component JS bundles does not contain CSS because the CSS will be pre-rendered and embedded in the page HTML.