### PR TITLE
Force runes mode for symbols

### DIFF
--- a/app/lib/PageData.svelte.ts
+++ b/app/lib/PageData.svelte.ts
@@ -2,20 +2,39 @@ import type { ObjectOf } from './pocketbase/CollectionMapping'
 import { Pages, PageTypes, Sites, SiteSymbols } from './pocketbase/collections'
 
 export const usePageData = (site?: ObjectOf<typeof Sites>, pages?: ObjectOf<typeof Pages>[]) => {
-	const page_types = $derived(pages?.every((page) => PageTypes.one(page.page_type) !== undefined) ? pages.flatMap((page) => PageTypes.one(page.page_type) ?? []) : undefined)
-	const page_sections = $derived(pages?.every((page) => page.sections() !== undefined) ? pages.flatMap((page) => page.sections() ?? []) : undefined)
-	const page_type_sections = $derived(page_types?.every((page_type) => page_type.sections() !== undefined) ? page_types.flatMap((page_type) => page_type.sections() ?? []) : undefined)
-	const page_type_symbols = $derived(page_types?.every((page_type) => page_type.symbols() !== undefined) ? page_types.flatMap((page_type) => page_type.symbols() ?? []) : undefined)
-	const symbols = $derived(page_sections && page_type_sections && [...page_sections, ...page_type_sections].map((section) => SiteSymbols.one(section.symbol)).filter((symbol) => symbol !== undefined))
+	const page_types = $derived(pages?.every((page) => PageTypes.one(page.page_type) !== undefined) ? pages.flatMap((page) => PageTypes.one(page.page_type) ?? []).filter(deduplicate('id')) : undefined)
+	const page_sections = $derived(pages?.every((page) => page.sections() !== undefined) ? pages.flatMap((page) => page.sections() ?? []).filter(deduplicate('id')) : undefined)
+	const page_type_sections = $derived(
+		page_types?.every((page_type) => page_type.sections() !== undefined) ? page_types.flatMap((page_type) => page_type.sections() ?? []).filter(deduplicate('id')) : undefined
+	)
+	const page_type_symbols = $derived(
+		page_types?.every((page_type) => page_type.symbols() !== undefined) ? page_types.flatMap((page_type) => page_type.symbols() ?? []).filter(deduplicate('id')) : undefined
+	)
+	const symbols = $derived(
+		page_sections &&
+			page_type_sections &&
+			[...page_sections, ...page_type_sections]
+				.map((section) => SiteSymbols.one(section.symbol))
+				.filter((symbol) => symbol !== undefined)
+				.filter(deduplicate('id'))
+	)
 	const site_fields = $derived(site?.fields())
-	const page_type_fields = $derived(page_types?.every((page_type) => page_type.fields() !== undefined) ? page_types.flatMap((page_type) => page_type.fields() ?? []) : undefined)
-	const symbol_fields = $derived(symbols?.every((symbol) => symbol.fields() !== undefined) ? symbols.flatMap((symbol) => symbol.fields() ?? []) : undefined)
+	const page_type_fields = $derived(
+		page_types?.every((page_type) => page_type.fields() !== undefined) ? page_types.flatMap((page_type) => page_type.fields() ?? []).filter(deduplicate('id')) : undefined
+	)
+	const symbol_fields = $derived(symbols?.every((symbol) => symbol.fields() !== undefined) ? symbols.flatMap((symbol) => symbol.fields() ?? []).filter(deduplicate('id')) : undefined)
 	const site_entries = $derived(site?.entries())
-	const page_type_entries = $derived(page_types?.every((page_type) => page_type.entries() !== undefined) ? page_types.flatMap((page_type) => page_type.entries() ?? []) : undefined)
-	const symbol_entries = $derived(symbols?.every((symbol) => symbol.entries() !== undefined) ? symbols.flatMap((symbol) => symbol.entries() ?? []) : undefined)
-	const page_entries = $derived(pages?.every((page) => page.entries() !== undefined) ? pages.flatMap((page) => page.entries() ?? []) : undefined)
-	const page_section_entries = $derived(page_sections?.every((section) => section.entries() !== undefined) ? page_sections.flatMap((section) => section.entries() ?? []) : undefined)
-	const page_type_section_entries = $derived(page_type_sections?.every((section) => section.entries() !== undefined) ? page_type_sections.flatMap((section) => section.entries() ?? []) : undefined)
+	const page_type_entries = $derived(
+		page_types?.every((page_type) => page_type.entries() !== undefined) ? page_types.flatMap((page_type) => page_type.entries() ?? []).filter(deduplicate('id')) : undefined
+	)
+	const symbol_entries = $derived(symbols?.every((symbol) => symbol.entries() !== undefined) ? symbols.flatMap((symbol) => symbol.entries() ?? []).filter(deduplicate('id')) : undefined)
+	const page_entries = $derived(pages?.every((page) => page.entries() !== undefined) ? pages.flatMap((page) => page.entries() ?? []).filter(deduplicate('id')) : undefined)
+	const page_section_entries = $derived(
+		page_sections?.every((section) => section.entries() !== undefined) ? page_sections.flatMap((section) => section.entries() ?? []).filter(deduplicate('id')) : undefined
+	)
+	const page_type_section_entries = $derived(
+		page_type_sections?.every((section) => section.entries() !== undefined) ? page_type_sections.flatMap((section) => section.entries() ?? []).filter(deduplicate('id')) : undefined
+	)
 
 	return new (class {
 		data = $derived(
@@ -55,3 +74,8 @@ export const usePageData = (site?: ObjectOf<typeof Sites>, pages?: ObjectOf<type
 		)
 	})()
 }
+
+const deduplicate =
+	<T>(key: keyof T) =>
+	(item: T, index: number, array: T[]) =>
+		array.findIndex((value) => value[key] === item[key]) === index

--- a/app/lib/compiler/workers/rollup.worker.js
+++ b/app/lib/compiler/workers/rollup.worker.js
@@ -30,10 +30,12 @@ async function rollup_worker({ component, head, hydrated, buildStatic = true, cs
 				${head.code}
 			</svelte:head>
 			<script>
-				${components.map((_, i) => `import Component_${i} from './Component_${i}.svelte';`).join('\n')}
-				${components.map((_, i) => `export let component_${i}_props`).join(`\n`)}
+			  let props = $props();
 
-				export let head_props
+				${components.map((_, i) => `import Component_${i} from './Component_${i}.svelte';`).join('\n')}
+				${components.map((_, i) => `let { component_${i}_props } = props;`).join(`\n`)}
+
+				let { head_props } = props;
 				${field_keys.map((field) => `let ${field[0]} = head_props['${field[0]}'];`).join(`\n`)}
 			</script>
 			${components.map((component, i) => `<Component_${i} {...component_${i}_props} /> \n`).join('')}
@@ -56,7 +58,7 @@ async function rollup_worker({ component, head, hydrated, buildStatic = true, cs
 		return `\
 					${html}
           <script>
-            ${field_keys.map((field) => `let ${field[0]} = $$props['${field[0]}'];`).join(`\n`) /* e.g. let heading = props['heading'] */}
+            ${`let { ${field_keys.join(', ')} } = $props();` /* e.g. let { heading, body } = $props(); */}
             ${js}
           </script>
           ${css ? `<style>${css}</style>` : ``}`
@@ -82,7 +84,8 @@ async function rollup_worker({ component, head, hydrated, buildStatic = true, cs
 	if (buildStatic) {
 		const bundle = await compile({
 			generate: 'server',
-			css: 'injected'
+			css: 'injected',
+			runes: true
 		})
 
 		const output = (await bundle.generate({ format })).output[0].code
@@ -91,7 +94,8 @@ async function rollup_worker({ component, head, hydrated, buildStatic = true, cs
 		const bundle = await compile({
 			generate: 'client',
 			css,
-			dev: dev_mode
+			dev: dev_mode,
+			runes: true
 		})
 
 		const output = (await bundle.generate({ format })).output[0].code
@@ -102,7 +106,8 @@ async function rollup_worker({ component, head, hydrated, buildStatic = true, cs
 	if (hydrated) {
 		const bundle = await compile({
 			generate: 'client',
-			css: 'external'
+			css: 'external',
+			runes: true
 		})
 		const output = (await bundle.generate({ format })).output[0].code
 		final.dom = output


### PR DESCRIPTION
## Changes

- **Deduplicate usePageData**
  Fixes duplicate requests (causing request cancellations) on publish

-  **Force runes mode for symbols**
  All symbols must use Svelte runes instead of legacy Svelte code. This is necessary for supporting runes at all, and legacy mode will be deprecated in Svelte at some point anyways.